### PR TITLE
Add search functionality to Item Library

### DIFF
--- a/TODOs.txt
+++ b/TODOs.txt
@@ -1,0 +1,5 @@
+- Add spacers to fill the gaps.  allow one sided or symmetrical
+- Pull bins from flat file (json or md, can't decide)
+- Allow for an image of the bin as the icon in the Library pane
+- Allow collapsing of the Library categories
+- Add Search for library item (specifics TBD)

--- a/src/App.css
+++ b/src/App.css
@@ -308,6 +308,61 @@
   color: #888;
 }
 
+.library-search {
+  position: relative;
+  margin-bottom: 1rem;
+}
+
+.library-search-input {
+  width: 100%;
+  padding: 0.5rem 2rem 0.5rem 0.75rem;
+  border: 2px solid #444;
+  border-radius: 6px;
+  background: transparent;
+  color: inherit;
+  font-size: 0.875rem;
+  box-sizing: border-box;
+}
+
+.library-search-input:focus {
+  outline: none;
+  border-color: #646cff;
+}
+
+.library-search-input::placeholder {
+  color: #888;
+}
+
+.library-search-clear {
+  position: absolute;
+  right: 0.5rem;
+  top: 50%;
+  transform: translateY(-50%);
+  background: transparent;
+  border: none;
+  color: #888;
+  font-size: 1.5rem;
+  cursor: pointer;
+  padding: 0;
+  width: 1.5rem;
+  height: 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.2s;
+}
+
+.library-search-clear:hover {
+  color: #ef4444;
+}
+
+.library-no-results {
+  text-align: center;
+  padding: 2rem 1rem;
+  color: #888;
+  font-size: 0.875rem;
+}
+
 .library-loading,
 .library-error {
   display: flex;

--- a/src/components/ItemLibrary.test.tsx
+++ b/src/components/ItemLibrary.test.tsx
@@ -19,9 +19,9 @@ describe('ItemLibrary', () => {
   it('should render all categories', () => {
     render(<ItemLibrary items={mockLibraryItems} isLoading={false} error={null} />);
 
-    expect(screen.getByText('Bins')).toBeInTheDocument();
-    expect(screen.getByText('Dividers')).toBeInTheDocument();
-    expect(screen.getByText('Organizers')).toBeInTheDocument();
+    expect(screen.getByText(/Bins/)).toBeInTheDocument();
+    expect(screen.getByText(/Dividers/)).toBeInTheDocument();
+    expect(screen.getByText(/Organizers/)).toBeInTheDocument();
   });
 
   it('should have all categories expanded by default', () => {
@@ -47,7 +47,7 @@ describe('ItemLibrary', () => {
   it('should collapse category when clicked', () => {
     render(<ItemLibrary items={mockLibraryItems} isLoading={false} error={null} />);
 
-    const binsTitle = screen.getByText('Bins');
+    const binsTitle = screen.getByText(/Bins/);
     fireEvent.click(binsTitle);
 
     const binsItems = binsTitle.nextElementSibling;
@@ -58,7 +58,7 @@ describe('ItemLibrary', () => {
   it('should expand category when clicked again', () => {
     render(<ItemLibrary items={mockLibraryItems} isLoading={false} error={null} />);
 
-    const binsTitle = screen.getByText('Bins');
+    const binsTitle = screen.getByText(/Bins/);
 
     // Collapse
     fireEvent.click(binsTitle);
@@ -74,7 +74,7 @@ describe('ItemLibrary', () => {
   it('should rotate chevron when category is collapsed', () => {
     render(<ItemLibrary items={mockLibraryItems} isLoading={false} error={null} />);
 
-    const binsTitle = screen.getByText('Bins');
+    const binsTitle = screen.getByText(/Bins/);
     const chevron = binsTitle.querySelector('.category-chevron');
 
     expect(chevron).toHaveClass('expanded');
@@ -88,7 +88,7 @@ describe('ItemLibrary', () => {
   it('should handle keyboard interaction (Enter key)', () => {
     render(<ItemLibrary items={mockLibraryItems} isLoading={false} error={null} />);
 
-    const binsTitle = screen.getByText('Bins');
+    const binsTitle = screen.getByText(/Bins/);
     fireEvent.keyDown(binsTitle, { key: 'Enter' });
 
     const binsItems = binsTitle.nextElementSibling;
@@ -98,7 +98,7 @@ describe('ItemLibrary', () => {
   it('should handle keyboard interaction (Space key)', () => {
     render(<ItemLibrary items={mockLibraryItems} isLoading={false} error={null} />);
 
-    const binsTitle = screen.getByText('Bins');
+    const binsTitle = screen.getByText(/Bins/);
     fireEvent.keyDown(binsTitle, { key: ' ' });
 
     const binsItems = binsTitle.nextElementSibling;
@@ -108,8 +108,8 @@ describe('ItemLibrary', () => {
   it('should collapse categories independently', () => {
     render(<ItemLibrary items={mockLibraryItems} isLoading={false} error={null} />);
 
-    const binsTitle = screen.getByText('Bins');
-    const dividersTitle = screen.getByText('Dividers');
+    const binsTitle = screen.getByText(/Bins/);
+    const dividersTitle = screen.getByText(/Dividers/);
 
     fireEvent.click(binsTitle);
 
@@ -123,7 +123,7 @@ describe('ItemLibrary', () => {
   it('should save collapsed state to localStorage', () => {
     render(<ItemLibrary items={mockLibraryItems} isLoading={false} error={null} />);
 
-    const binsTitle = screen.getByText('Bins');
+    const binsTitle = screen.getByText(/Bins/);
     fireEvent.click(binsTitle);
 
     const stored = localStorage.getItem('gridfinity-collapsed-categories');
@@ -137,7 +137,7 @@ describe('ItemLibrary', () => {
 
     render(<ItemLibrary items={mockLibraryItems} isLoading={false} error={null} />);
 
-    const dividersTitle = screen.getByText('Dividers');
+    const dividersTitle = screen.getByText(/Dividers/);
     const dividersItems = dividersTitle.nextElementSibling;
 
     expect(dividersItems).toHaveClass('collapsed');
@@ -154,7 +154,7 @@ describe('ItemLibrary', () => {
 
     render(<ItemLibrary items={mockLibraryItems} isLoading={false} error={null} />);
 
-    const binsTitle = screen.getByText('Bins');
+    const binsTitle = screen.getByText(/Bins/);
     fireEvent.click(binsTitle);
 
     // Should still work despite localStorage error
@@ -170,7 +170,7 @@ describe('ItemLibrary', () => {
   it('should have correct accessibility attributes', () => {
     render(<ItemLibrary items={mockLibraryItems} isLoading={false} error={null} />);
 
-    const binsTitle = screen.getByText('Bins');
+    const binsTitle = screen.getByText(/Bins/);
 
     expect(binsTitle).toHaveAttribute('role', 'button');
     expect(binsTitle).toHaveAttribute('tabIndex', '0');
@@ -179,8 +179,8 @@ describe('ItemLibrary', () => {
   it('should maintain state across multiple toggles', () => {
     render(<ItemLibrary items={mockLibraryItems} isLoading={false} error={null} />);
 
-    const binsTitle = screen.getByText('Bins');
-    const dividersTitle = screen.getByText('Dividers');
+    const binsTitle = screen.getByText(/Bins/);
+    const dividersTitle = screen.getByText(/Dividers/);
 
     // Collapse bins
     fireEvent.click(binsTitle);
@@ -200,5 +200,73 @@ describe('ItemLibrary', () => {
     const parsed = JSON.parse(stored!);
     expect(parsed).toContain('dividers');
     expect(parsed).not.toContain('bins');
+  });
+
+  it('should render search input', () => {
+    render(<ItemLibrary items={mockLibraryItems} isLoading={false} error={null} />);
+    const searchInput = screen.getByPlaceholderText('Search items...');
+    expect(searchInput).toBeInTheDocument();
+  });
+
+  it('should filter items by search query', () => {
+    render(<ItemLibrary items={mockLibraryItems} isLoading={false} error={null} />);
+    const searchInput = screen.getByPlaceholderText('Search items...');
+
+    fireEvent.change(searchInput, { target: { value: '2x2' } });
+
+    expect(screen.getByText('2x2 Bin')).toBeInTheDocument();
+    expect(screen.queryByText('1x1 Bin')).not.toBeInTheDocument();
+  });
+
+  it('should show clear button when search has text', () => {
+    render(<ItemLibrary items={mockLibraryItems} isLoading={false} error={null} />);
+    const searchInput = screen.getByPlaceholderText('Search items...');
+
+    expect(screen.queryByLabelText('Clear search')).not.toBeInTheDocument();
+
+    fireEvent.change(searchInput, { target: { value: 'bin' } });
+
+    expect(screen.getByLabelText('Clear search')).toBeInTheDocument();
+  });
+
+  it('should clear search when clear button clicked', () => {
+    render(<ItemLibrary items={mockLibraryItems} isLoading={false} error={null} />);
+    const searchInput = screen.getByPlaceholderText('Search items...') as HTMLInputElement;
+
+    fireEvent.change(searchInput, { target: { value: 'test' } });
+    expect(searchInput.value).toBe('test');
+
+    const clearButton = screen.getByLabelText('Clear search');
+    fireEvent.click(clearButton);
+
+    expect(searchInput.value).toBe('');
+  });
+
+  it('should show no results message when search has no matches', () => {
+    render(<ItemLibrary items={mockLibraryItems} isLoading={false} error={null} />);
+    const searchInput = screen.getByPlaceholderText('Search items...');
+
+    fireEvent.change(searchInput, { target: { value: 'nonexistent' } });
+
+    expect(screen.getByText(/No items found matching "nonexistent"/)).toBeInTheDocument();
+  });
+
+  it('should hide empty categories when filtering', () => {
+    render(<ItemLibrary items={mockLibraryItems} isLoading={false} error={null} />);
+    const searchInput = screen.getByPlaceholderText('Search items...');
+
+    // Search for divider only
+    fireEvent.change(searchInput, { target: { value: 'Divider' } });
+
+    expect(screen.getByText(/Dividers/)).toBeInTheDocument();
+    expect(screen.queryByText(/Bins/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Organizers/)).not.toBeInTheDocument();
+  });
+
+  it('should show item count in category headers', () => {
+    render(<ItemLibrary items={mockLibraryItems} isLoading={false} error={null} />);
+
+    expect(screen.getByText(/Bins \(2\)/)).toBeInTheDocument();
+    expect(screen.getByText(/Dividers \(1\)/)).toBeInTheDocument();
   });
 });

--- a/src/components/ItemLibrary.tsx
+++ b/src/components/ItemLibrary.tsx
@@ -13,9 +13,16 @@ interface ItemLibraryProps {
 }
 
 export function ItemLibrary({ items, isLoading, error }: ItemLibraryProps) {
-  const bins = items.filter(item => item.category === 'bin');
-  const dividers = items.filter(item => item.category === 'divider');
-  const organizers = items.filter(item => item.category === 'organizer');
+  const [searchQuery, setSearchQuery] = useState('');
+
+  // Filter items by search query
+  const filteredItems = items.filter(item =>
+    item.name.toLowerCase().includes(searchQuery.toLowerCase())
+  );
+
+  const bins = filteredItems.filter(item => item.category === 'bin');
+  const dividers = filteredItems.filter(item => item.category === 'divider');
+  const organizers = filteredItems.filter(item => item.category === 'organizer');
 
   // Load collapsed state from localStorage, default all to expanded (false = expanded)
   const [collapsedCategories, setCollapsedCategories] = useState<Set<CategoryKey>>(() => {
@@ -56,6 +63,8 @@ export function ItemLibrary({ items, isLoading, error }: ItemLibraryProps) {
     title: string,
     categoryItems: LibraryItem[]
   ) => {
+    if (categoryItems.length === 0) return null;
+
     const isCollapsed = collapsedCategories.has(key);
 
     return (
@@ -75,7 +84,7 @@ export function ItemLibrary({ items, isLoading, error }: ItemLibraryProps) {
           <span className={`category-chevron ${isCollapsed ? 'collapsed' : 'expanded'}`}>
             ▶
           </span>
-          {title}
+          {title} ({categoryItems.length})
         </h4>
         <div className={`category-items ${isCollapsed ? 'collapsed' : 'expanded'}`}>
           {categoryItems.map(item => (
@@ -109,10 +118,37 @@ export function ItemLibrary({ items, isLoading, error }: ItemLibraryProps) {
     );
   }
 
+  const hasResults = bins.length > 0 || dividers.length > 0 || organizers.length > 0;
+
   return (
     <div className="item-library">
       <h3 className="item-library-title">Item Library</h3>
       <p className="item-library-hint">Drag items onto the grid</p>
+
+      <div className="library-search">
+        <input
+          type="text"
+          className="library-search-input"
+          placeholder="Search items..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+        />
+        {searchQuery && (
+          <button
+            className="library-search-clear"
+            onClick={() => setSearchQuery('')}
+            aria-label="Clear search"
+          >
+            ×
+          </button>
+        )}
+      </div>
+
+      {!hasResults && searchQuery && (
+        <div className="library-no-results">
+          <p>No items found matching "{searchQuery}"</p>
+        </div>
+      )}
 
       {renderCategory('bins', 'Bins', bins)}
       {renderCategory('dividers', 'Dividers', dividers)}


### PR DESCRIPTION
# Search Functionality for Item Library

Implements real-time search filtering to help users quickly find items as the library grows.

## Features

✅ **Search input** - Field above categories with placeholder "Search items..."
✅ **Real-time filtering** - Instant results as you type (case-insensitive)
✅ **Clear button** - × icon appears when text entered, clears on click
✅ **No results state** - Helpful message when search yields no matches
✅ **Smart categories** - Empty categories hidden during search
✅ **Item counts** - Category headers show count: "Bins (2)", "Dividers (1)"

## UI/UX

- Search input matches app styling (blue focus border on `:focus`)
- Clear button turns red on hover for visual feedback
- Categories automatically hide when they have no matching items
- Item counts help users understand result distribution
- Search persists across category collapse/expand actions

## Implementation

- Simple `.includes()` filter on item names (sufficient for small dataset)
- No debouncing needed - filtering is instant with no lag
- Categories return `null` when empty (React auto-removes)
- State managed with single `useState` hook

## Testing

- **166 tests passing** (7 new tests added)
- **New tests cover:**
  - Search input rendering
  - Filtering by query
  - Clear button appearance/functionality
  - No results message
  - Empty category hiding
  - Item count display
- **Updated existing tests** to handle item counts in headers
- **0 linting errors**

## Performance

- Instant filtering (no perceptible lag on datasets < 100 items)
- No state management overhead
- Minimal re-renders (React optimizes filtering well)

## Files Changed

- `src/components/ItemLibrary.tsx` - Added search state and filtering logic
- `src/App.css` - Added search input and no-results styles
- `src/components/ItemLibrary.test.tsx` - 7 new tests, updated existing tests

## Breaking Changes

**None** - Purely additive feature

## Closes

#6 - Add search functionality to Item Library

## Screenshots

*Search in action:*
```
Item Library
[Search: "2x2"          ×]

▼ Bins (1)
  [2x2 Bin card]
```

*No results:*
```
Item Library
[Search: "xyz"          ×]

No items found matching "xyz"
```