### PR TITLE
Add library export functionality

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -386,6 +386,30 @@
   border-radius: 4px;
 }
 
+.export-library-button {
+  width: 100%;
+  padding: 0.6rem;
+  margin-bottom: 0.75rem;
+  border: 2px solid #10b981;
+  border-radius: 6px;
+  background: transparent;
+  color: #10b981;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.export-library-button:hover {
+  background: #10b981;
+  color: white;
+}
+
+.export-library-button:active {
+  background: #059669;
+  border-color: #059669;
+}
+
 .manage-library-button {
   width: 100%;
   padding: 0.75rem;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,24 @@ function App() {
     resetToDefaults,
   } = useLibraryData();
 
+  const handleExportLibrary = () => {
+    const libraryData = {
+      version: '1.0.0',
+      items: libraryItems,
+    };
+
+    const jsonString = JSON.stringify(libraryData, null, 2);
+    const blob = new Blob([jsonString], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `gridfinity-library-${new Date().toISOString().split('T')[0]}.json`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
   const handleUnitChange = (newUnit: UnitSystem) => {
     if (newUnit === unitSystem) return;
 
@@ -168,6 +186,7 @@ function App() {
             onUpdateItem={updateItem}
             onDeleteItem={deleteLibraryItem}
             onResetToDefaults={resetToDefaults}
+            onExportLibrary={handleExportLibrary}
           />
 
           {selectedItemId && (

--- a/src/components/ItemLibrary.test.tsx
+++ b/src/components/ItemLibrary.test.tsx
@@ -15,6 +15,7 @@ const mockWriteOps = {
   onUpdateItem: vi.fn(),
   onDeleteItem: vi.fn(),
   onResetToDefaults: vi.fn(),
+  onExportLibrary: vi.fn(),
 };
 
 describe('ItemLibrary', () => {
@@ -277,5 +278,21 @@ describe('ItemLibrary', () => {
 
     expect(screen.getByText(/Bins \(2\)/)).toBeInTheDocument();
     expect(screen.getByText(/Dividers \(1\)/)).toBeInTheDocument();
+  });
+
+  it('should render export library button', () => {
+    render(<ItemLibrary items={mockLibraryItems} isLoading={false} error={null} {...mockWriteOps} />);
+
+    const exportButton = screen.getByText('Export Library');
+    expect(exportButton).toBeInTheDocument();
+  });
+
+  it('should call onExportLibrary when export button is clicked', () => {
+    render(<ItemLibrary items={mockLibraryItems} isLoading={false} error={null} {...mockWriteOps} />);
+
+    const exportButton = screen.getByText('Export Library');
+    fireEvent.click(exportButton);
+
+    expect(mockWriteOps.onExportLibrary).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/ItemLibrary.tsx
+++ b/src/components/ItemLibrary.tsx
@@ -15,6 +15,7 @@ interface ItemLibraryProps {
   onUpdateItem: (id: string, updates: Partial<LibraryItem>) => void;
   onDeleteItem: (id: string) => void;
   onResetToDefaults: () => void;
+  onExportLibrary: () => void;
 }
 
 export function ItemLibrary({
@@ -25,6 +26,7 @@ export function ItemLibrary({
   onUpdateItem,
   onDeleteItem,
   onResetToDefaults,
+  onExportLibrary,
 }: ItemLibraryProps) {
   const [searchQuery, setSearchQuery] = useState('');
   const [showManager, setShowManager] = useState(false);
@@ -138,6 +140,14 @@ export function ItemLibrary({
     <div className="item-library">
       <h3 className="item-library-title">Item Library</h3>
       <p className="item-library-hint">Drag items onto the grid</p>
+
+      <button
+        className="export-library-button"
+        onClick={onExportLibrary}
+        title="Export library to JSON file"
+      >
+        Export Library
+      </button>
 
       <div className="library-search">
         <input

--- a/src/hooks/useLibraryData.test.ts
+++ b/src/hooks/useLibraryData.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { renderHook, waitFor, act } from '@testing-library/react';
 import { useLibraryData } from './useLibraryData';
+import type { LibraryItem } from '../types/gridfinity';
 
 describe('useLibraryData', () => {
   const mockLibraryData = {


### PR DESCRIPTION
## Summary
- Added export button to Item Library panel that allows users to download their custom library as a JSON file
- Addresses requirements miss where library changes were only saved to localStorage

## Changes
- Add handleExportLibrary function in App.tsx to generate and download JSON file
- Add Export Library button to ItemLibrary component (green outlined button at top of panel)
- Export file named with date: gridfinity-library-YYYY-MM-DD.json
- Update all tests to include onExportLibrary prop
- Fix missing LibraryItem import in useLibraryData.test.ts

## Test Plan
- [x] Export button renders correctly in Item Library
- [x] Clicking export button triggers download
- [x] Downloaded JSON contains version and items array
- [x] All existing tests still pass (185/185)
- [x] New tests added for export button functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)