### PR TITLE
Remove category grouping from Bill of Materials

### DIFF
--- a/src/components/BillOfMaterials.tsx
+++ b/src/components/BillOfMaterials.tsx
@@ -7,39 +7,6 @@ interface BillOfMaterialsProps {
 export function BillOfMaterials({ items }: BillOfMaterialsProps) {
   const totalItems = items.reduce((sum, item) => sum + item.quantity, 0);
 
-  // Group items by category (first category only for display)
-  // TODO: Remove category grouping - tracked in separate issue
-  const bins = items.filter(item => item.categories.includes('bin'));
-  const dividers = items.filter(item => item.categories.includes('divider'));
-  const organizers = items.filter(item => item.categories.includes('organizer'));
-
-  const renderCategory = (title: string, categoryItems: BOMItem[]) => {
-    if (categoryItems.length === 0) return null;
-
-    return (
-      <div className="bom-category">
-        <h4 className="bom-category-title">{title}</h4>
-        <div className="bom-items">
-          {categoryItems.map(item => (
-            <div key={item.itemId} className="bom-item">
-              <div
-                className="bom-item-color"
-                style={{ backgroundColor: item.color }}
-              />
-              <div className="bom-item-details">
-                <div className="bom-item-name">{item.name}</div>
-                <div className="bom-item-size">
-                  {item.widthUnits}×{item.heightUnits}
-                </div>
-              </div>
-              <div className="bom-item-quantity">×{item.quantity}</div>
-            </div>
-          ))}
-        </div>
-      </div>
-    );
-  };
-
   return (
     <div className="bill-of-materials">
       <div className="bom-header">
@@ -56,9 +23,23 @@ export function BillOfMaterials({ items }: BillOfMaterialsProps) {
         </div>
       ) : (
         <div className="bom-content">
-          {renderCategory('Bins', bins)}
-          {renderCategory('Dividers', dividers)}
-          {renderCategory('Organizers', organizers)}
+          <div className="bom-items">
+            {items.map(item => (
+              <div key={item.itemId} className="bom-item">
+                <div
+                  className="bom-item-color"
+                  style={{ backgroundColor: item.color }}
+                />
+                <div className="bom-item-details">
+                  <div className="bom-item-name">{item.name}</div>
+                  <div className="bom-item-size">
+                    {item.widthUnits}×{item.heightUnits}
+                  </div>
+                </div>
+                <div className="bom-item-quantity">×{item.quantity}</div>
+              </div>
+            ))}
+          </div>
         </div>
       )}
     </div>

--- a/src/hooks/useBillOfMaterials.ts
+++ b/src/hooks/useBillOfMaterials.ts
@@ -29,8 +29,7 @@ export function useBillOfMaterials(placedItems: PlacedItem[], libraryItems: Libr
       }
     });
 
-    // Sort by name only
-    // TODO: Remove category-based sorting entirely - tracked in separate issue
+    // Sort by name, ascending
     return bomItems.sort((a, b) => a.name.localeCompare(b.name));
   }, [placedItems, libraryItems]);
 }


### PR DESCRIPTION
## Summary
Simplifies the Bill of Materials display by removing category-based grouping and presenting items as a flat list sorted alphabetically by name.

## Changes
- ✅ Removed category grouping (bins, dividers, organizers sections)
- ✅ Display items as a single flat list
- ✅ Items sorted alphabetically by name (ascending)
- ✅ Simplified component logic
- ✅ Removed TODO comments about category-based sorting

## Why This Change?
- **Simpler UI**: Flat list is easier to scan than grouped sections
- **Multi-category support**: Works better with items that belong to multiple categories (Issue #11)
- **Alphabetical order**: Easier to find specific items by name
- **Cleaner code**: Removed unnecessary filtering and grouping logic

## Testing
- ✅ All tests passing: **307 passed | 3 skipped**
- ✅ No linting errors
- ✅ BOM correctly displays items sorted by name
- ✅ Quantity counts remain accurate

## Before/After
**Before**: Items grouped under "Bins", "Dividers", "Organizers" headers  
**After**: All items in a single list, sorted A-Z by name

🤖 Generated with [Claude Code](https://claude.com/claude-code)