### PR TITLE
Add optional image support for library item icons (closes #5)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -933,6 +933,37 @@
   border: 1px solid rgba(255, 255, 255, 0.3);
 }
 
+/* Library Item Image Support */
+.library-item-preview-container {
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 0.25rem;
+  position: relative;
+}
+
+.library-item-image {
+  width: 40px;
+  height: 40px;
+  object-fit: contain;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.02);
+  position: absolute;
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+
+.library-item-image.visible {
+  opacity: 1;
+}
+
+.library-item-image.hidden {
+  opacity: 0;
+  pointer-events: none;
+}
+
 .library-item-info {
   display: flex;
   flex-direction: column;

--- a/src/components/LibraryItemCard.tsx
+++ b/src/components/LibraryItemCard.tsx
@@ -1,10 +1,33 @@
+import { useState } from 'react';
 import type { LibraryItem, DragData } from '../types/gridfinity';
 
 interface LibraryItemCardProps {
   item: LibraryItem;
 }
 
+interface ImageState {
+  url: string | undefined;
+  loaded: boolean;
+  error: boolean;
+}
+
 export function LibraryItemCard({ item }: LibraryItemCardProps) {
+  const [imageState, setImageState] = useState<ImageState>({
+    url: item.imageUrl,
+    loaded: false,
+    error: false,
+  });
+
+  // Reset state if imageUrl has changed
+  if (imageState.url !== item.imageUrl) {
+    setImageState({
+      url: item.imageUrl,
+      loaded: false,
+      error: false,
+    });
+  }
+
+  const shouldShowImage = item.imageUrl && imageState.loaded && !imageState.error;
   const handleDragStart = (e: React.DragEvent) => {
     const dragData: DragData = {
       type: 'library',
@@ -36,8 +59,22 @@ export function LibraryItemCard({ item }: LibraryItemCardProps) {
       draggable
       onDragStart={handleDragStart}
     >
-      <div className="library-item-preview">
-        {previewCells}
+      <div className="library-item-preview-container">
+        {item.imageUrl && !imageState.error && (
+          <img
+            src={item.imageUrl}
+            alt={item.name}
+            className={`library-item-image ${shouldShowImage ? 'visible' : 'hidden'}`}
+            loading="lazy"
+            onLoad={() => setImageState(prev => ({ ...prev, loaded: true }))}
+            onError={() => setImageState(prev => ({ ...prev, error: true }))}
+          />
+        )}
+        {!shouldShowImage && (
+          <div className="library-item-preview">
+            {previewCells}
+          </div>
+        )}
       </div>
       <div className="library-item-info">
         <span className="library-item-name">{item.name}</span>

--- a/src/components/LibraryManager.tsx
+++ b/src/components/LibraryManager.tsx
@@ -45,6 +45,7 @@ export function LibraryManager({
     heightUnits: 1,
     color: '#646cff',
     categories: categories[0]?.id ? [categories[0].id] : ['bin'],
+    imageUrl: '',
   });
   const [error, setError] = useState<string | null>(null);
 
@@ -58,6 +59,7 @@ export function LibraryManager({
       heightUnits: 1,
       color: '#646cff',
       categories: categories[0]?.id ? [categories[0].id] : ['bin'],
+      imageUrl: '',
     });
     setError(null);
   };
@@ -180,6 +182,7 @@ export function LibraryManager({
                       <div className="item-name">{item.name}</div>
                       <div className="item-meta">
                         {item.widthUnits}×{item.heightUnits} units • {item.categories.join(', ')}
+                        {item.imageUrl && ' • Has image'}
                       </div>
                       <div className="item-id">ID: {item.id}</div>
                     </div>
@@ -300,6 +303,21 @@ export function LibraryManager({
                   pattern="^#[0-9A-Fa-f]{6}$"
                 />
               </div>
+            </div>
+
+            <div className="form-group">
+              <label htmlFor="item-image-url">Image URL (Optional)</label>
+              <input
+                id="item-image-url"
+                type="text"
+                value={formData.imageUrl || ''}
+                onChange={(e) => setFormData({ ...formData, imageUrl: e.target.value })}
+                placeholder="e.g., /icons/bin.png or https://example.com/icon.png"
+              />
+              <small>
+                Provide a URL to display an image icon instead of the colored grid preview.
+                Supports PNG, JPG, SVG, and WebP formats. Leave empty to use the grid preview.
+              </small>
             </div>
 
             <div className="form-actions">

--- a/src/types/gridfinity.ts
+++ b/src/types/gridfinity.ts
@@ -48,6 +48,7 @@ export interface LibraryItem {
   heightUnits: number;
   color: string;
   categories: string[];
+  imageUrl?: string;
 }
 
 export interface PlacedItem {


### PR DESCRIPTION
## Summary

Implements optional image/icon support for library items as described in issue #5. Users can now display custom images instead of the colored grid preview while maintaining full backward compatibility.

## Changes

- **Type Definition**: Added optional `imageUrl` field to `LibraryItem` interface
- **LibraryItemCard Component**: 
  - Conditional rendering of image vs grid preview
  - State management to handle image loading with automatic reset on URL changes
  - Lazy loading for performance
  - Graceful fallback to grid preview on any error
- **CSS Styling**: 
  - Added image container with opacity-based visibility
  - Smooth fade-in transition when image loads
  - Used opacity instead of display:none to ensure browsers load images
- **LibraryManager Form**: 
  - New optional imageUrl input field
  - Help text with usage examples
  - "Has image" indicator in item list

## Key Features

✅ Fully backward compatible - existing items work unchanged
✅ Automatic fallback to grid preview on image errors (404, CORS, network issues)
✅ Native lazy loading for performance
✅ No user-facing error messages (graceful degradation)
✅ Smooth fade-in animation when images load
✅ Supports relative URLs (e.g., `/icons/bin.png`) and absolute URLs

## Testing

- ✅ Linter passes with no errors
- ✅ Existing items without imageUrl display grid preview
- ✅ Items with valid imageUrl display images correctly
- ✅ Invalid URLs gracefully fall back to grid preview
- ✅ Drag and drop functionality works with both image and grid items
- ✅ Image state resets properly when URL changes

## Example Usage

Add an image URL in Library Manager:
- Relative: `/vite.svg`
- Absolute: `https://example.com/icon.png`

Leave empty to use the default grid preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)