### PR TITLE
Add GitHub Actions workflow for Docker Hub publishing

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,53 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+env:
+  REGISTRY: docker.io
+  IMAGE_NAME: ninjabuffalo/gridfinity-customizer
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ninjabuffalo
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

Adds automated Docker image building and publishing to Docker Hub.

**Triggers:**
- Push to `main` branch → tagged as `latest`
- Version tags (`v*.*.*`) → tagged with version number
- Manual workflow dispatch

**Image:** `ninjabuffalo/gridfinity-customizer`

## Setup

GitHub secret `DOCKERHUB_TOKEN` has been configured.

## Test plan

- [ ] Merge to develop, then to main
- [ ] Verify workflow runs on push to main
- [ ] Verify image appears at https://hub.docker.com/r/ninjabuffalo/gridfinity-customizer

https://claude.ai/code/session_01N5X8NpRbsWkxtzmmt7MRU4