### PR TITLE
feat(grid): inline delete button, keyboard shortcuts, and clear all

### DIFF
--- a/e2e/tests/item-manipulation.spec.ts
+++ b/e2e/tests/item-manipulation.spec.ts
@@ -91,6 +91,151 @@ test.describe('Item Manipulation', () => {
     await expect(itemControls).not.toBeVisible();
   });
 
+  test('Delete key removes selected item', async ({ page }) => {
+    const firstItem = libraryPage.libraryItems.first();
+    await dragToGridCell(page, firstItem, gridPage.gridContainer, 0, 0, 4, 4);
+
+    expect(await gridPage.getPlacedItemCount()).toBe(1);
+
+    await page.keyboard.press('Delete');
+    await page.waitForTimeout(100);
+
+    expect(await gridPage.getPlacedItemCount()).toBe(0);
+  });
+
+  test('Backspace key removes selected item', async ({ page }) => {
+    const firstItem = libraryPage.libraryItems.first();
+    await dragToGridCell(page, firstItem, gridPage.gridContainer, 0, 0, 4, 4);
+
+    expect(await gridPage.getPlacedItemCount()).toBe(1);
+
+    await page.keyboard.press('Backspace');
+    await page.waitForTimeout(100);
+
+    expect(await gridPage.getPlacedItemCount()).toBe(0);
+  });
+
+  test('R key rotates selected item', async ({ page }) => {
+    const firstItem = libraryPage.libraryItems.first();
+    await dragToGridCell(page, firstItem, gridPage.gridContainer, 0, 0, 4, 4);
+
+    const placedItem = page.locator('.placed-item').first();
+    const initialBox = await placedItem.boundingBox();
+    expect(initialBox).not.toBeNull();
+
+    await page.keyboard.press('r');
+    await page.waitForTimeout(100);
+
+    const newBox = await placedItem.boundingBox();
+    expect(newBox).not.toBeNull();
+  });
+
+  test('keyboard shortcuts do not fire when typing in input', async ({ page }) => {
+    const firstItem = libraryPage.libraryItems.first();
+    await dragToGridCell(page, firstItem, gridPage.gridContainer, 0, 0, 4, 4);
+
+    expect(await gridPage.getPlacedItemCount()).toBe(1);
+
+    // Focus on a dimension input and type Delete — should not remove the item
+    const widthInput = page.locator('input').first();
+    await widthInput.focus();
+    await page.keyboard.press('Delete');
+    await page.waitForTimeout(100);
+
+    expect(await gridPage.getPlacedItemCount()).toBe(1);
+  });
+
+  test('Clear All button shows with count and removes all items', async ({ page }) => {
+    const clearAllButton = page.locator('.clear-all-button');
+
+    // Button should not be visible with no items
+    await expect(clearAllButton).not.toBeVisible();
+
+    // Place two items
+    const firstItem = libraryPage.libraryItems.first();
+    await dragToGridCell(page, firstItem, gridPage.gridContainer, 0, 0, 4, 4);
+    await dragToGridCell(page, firstItem, gridPage.gridContainer, 2, 0, 4, 4);
+
+    expect(await gridPage.getPlacedItemCount()).toBe(2);
+
+    // Button should be visible with count
+    await expect(clearAllButton).toBeVisible();
+    await expect(clearAllButton).toContainText('Clear All (2)');
+
+    // Accept the confirm dialog
+    page.on('dialog', dialog => dialog.accept());
+    await clearAllButton.click();
+    await page.waitForTimeout(100);
+
+    // All items should be removed
+    expect(await gridPage.getPlacedItemCount()).toBe(0);
+
+    // Button should be hidden again
+    await expect(clearAllButton).not.toBeVisible();
+  });
+
+  test('Clear All button hidden when no items placed', async ({ page }) => {
+    const clearAllButton = page.locator('.clear-all-button');
+    await expect(clearAllButton).not.toBeVisible();
+  });
+
+  test('inline delete button removes selected item', async ({ page }) => {
+    // Place an item
+    const firstItem = libraryPage.libraryItems.first();
+    await dragToGridCell(page, firstItem, gridPage.gridContainer, 0, 0, 4, 4);
+
+    expect(await gridPage.getPlacedItemCount()).toBe(1);
+
+    // Item should be selected after placement — delete button should be visible
+    const deleteBtn = page.locator('.placed-item-delete-btn');
+    await expect(deleteBtn).toBeVisible();
+
+    // Click the inline delete button
+    await deleteBtn.click();
+    await page.waitForTimeout(100);
+
+    // Item should be removed
+    expect(await gridPage.getPlacedItemCount()).toBe(0);
+  });
+
+  test('inline delete button not visible when no item selected', async ({ page }) => {
+    // Place an item
+    const firstItem = libraryPage.libraryItems.first();
+    await dragToGridCell(page, firstItem, gridPage.gridContainer, 0, 0, 4, 4);
+
+    // Deselect by clicking empty area
+    await gridPage.clickEmptyGridArea();
+    await page.waitForTimeout(100);
+
+    // Delete button should not be visible
+    const deleteBtn = page.locator('.placed-item-delete-btn');
+    await expect(deleteBtn).not.toBeVisible();
+  });
+
+  test('inline delete button removes correct item with multiple items', async ({ page }) => {
+    // Place two items
+    const firstItem = libraryPage.libraryItems.first();
+    await dragToGridCell(page, firstItem, gridPage.gridContainer, 0, 0, 4, 4);
+    await dragToGridCell(page, firstItem, gridPage.gridContainer, 2, 0, 4, 4);
+
+    expect(await gridPage.getPlacedItemCount()).toBe(2);
+
+    // Second item should be selected (most recently placed)
+    // Click the first item to select it
+    const placedItems = page.locator('.placed-item');
+    await placedItems.first().click();
+    await page.waitForTimeout(50);
+
+    // Delete button should be on the selected (first) item
+    const deleteBtn = page.locator('.placed-item-delete-btn');
+    await expect(deleteBtn).toBeVisible();
+    await deleteBtn.click();
+    await page.waitForTimeout(100);
+
+    // Should have 1 item remaining
+    expect(await gridPage.getPlacedItemCount()).toBe(1);
+  });
+
   test('can select a placed item by clicking on it', async ({ page }) => {
     // Place first item at cell (0,0)
     const firstItem = libraryPage.libraryItems.first();

--- a/src/App.css
+++ b/src/App.css
@@ -1163,6 +1163,50 @@
   letter-spacing: var(--tracking-wide);
 }
 
+/* Placed Item Inline Delete Button */
+.placed-item-delete-btn {
+  position: absolute;
+  top: -8px;
+  right: -8px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 1.5px solid var(--border-secondary);
+  background: var(--bg-primary);
+  color: var(--text-tertiary);
+  font-size: 12px;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  z-index: 3;
+  padding: 0;
+  animation: delete-btn-appear 0.15s ease-out;
+}
+
+.placed-item-delete-btn:hover {
+  background: var(--invalid-primary);
+  border-color: var(--invalid-primary);
+  color: white;
+  transform: scale(1.15);
+}
+
+.placed-item-delete-btn:active {
+  transform: scale(0.95);
+}
+
+@keyframes delete-btn-appear {
+  from {
+    opacity: 0;
+    transform: scale(0.5);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
 /* Placed Item Image Support */
 .placed-item-image-container {
   position: absolute;
@@ -1435,6 +1479,26 @@
   .bom-sidebar {
     order: 1;
   }
+}
+
+/* Clear All Button */
+.clear-all-button {
+  padding: var(--space-sm) var(--space-lg);
+  border: 2px solid var(--invalid-primary);
+  border-radius: var(--radius-lg);
+  background: transparent;
+  color: var(--invalid-primary);
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  font-family: var(--font-body);
+  cursor: pointer;
+  transition: all 0.2s;
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wide);
+}
+
+.clear-all-button:hover {
+  background: var(--invalid-alpha-40);
 }
 
 /* Reference Image Overlay */

--- a/src/components/GridPreview.tsx
+++ b/src/components/GridPreview.tsx
@@ -13,6 +13,7 @@ interface GridPreviewProps {
   onDrop: (dragData: DragData, x: number, y: number) => void;
   onSelectItem: (instanceId: string | null) => void;
   getItemById: (id: string) => LibraryItem | undefined;
+  onDeleteItem?: (instanceId: string) => void;
   referenceImages?: ReferenceImage[];
   interactionMode?: InteractionMode;
   selectedImageId?: string | null;
@@ -29,6 +30,7 @@ export function GridPreview({
   onDrop,
   onSelectItem,
   getItemById,
+  onDeleteItem,
   referenceImages = [],
   interactionMode = 'items',
   onImagePositionChange,
@@ -149,6 +151,7 @@ export function GridPreview({
                 isSelected={item.instanceId === selectedItemId}
                 onSelect={onSelectItem}
                 getItemById={getItemById}
+                onDelete={onDeleteItem}
               />
             ))}
           </div>

--- a/src/components/PlacedItemOverlay.test.tsx
+++ b/src/components/PlacedItemOverlay.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { PlacedItemOverlay } from './PlacedItemOverlay';
 import type { PlacedItemWithValidity, LibraryItem } from '../types/gridfinity';
@@ -615,6 +615,166 @@ describe('PlacedItemOverlay', () => {
         width: '2%',
         height: '3%',
       });
+    });
+  });
+
+  describe('Inline Delete Button', () => {
+    const mockOnDelete = vi.fn();
+
+    beforeEach(() => {
+      mockOnDelete.mockClear();
+    });
+
+    it('should render delete button when selected and onDelete provided', () => {
+      const item = createMockItem();
+      render(
+        <PlacedItemOverlay
+          item={item}
+          gridX={4}
+          gridY={4}
+          isSelected={true}
+          onSelect={mockOnSelect}
+          getItemById={mockGetItemById}
+          onDelete={mockOnDelete}
+        />
+      );
+
+      const deleteBtn = screen.getByRole('button', { name: 'Remove item' });
+      expect(deleteBtn).toBeInTheDocument();
+    });
+
+    it('should NOT render delete button when not selected', () => {
+      const item = createMockItem();
+      render(
+        <PlacedItemOverlay
+          item={item}
+          gridX={4}
+          gridY={4}
+          isSelected={false}
+          onSelect={mockOnSelect}
+          getItemById={mockGetItemById}
+          onDelete={mockOnDelete}
+        />
+      );
+
+      expect(screen.queryByRole('button', { name: 'Remove item' })).not.toBeInTheDocument();
+    });
+
+    it('should NOT render delete button when onDelete not provided', () => {
+      const item = createMockItem();
+      render(
+        <PlacedItemOverlay
+          item={item}
+          gridX={4}
+          gridY={4}
+          isSelected={true}
+          onSelect={mockOnSelect}
+          getItemById={mockGetItemById}
+        />
+      );
+
+      expect(screen.queryByRole('button', { name: 'Remove item' })).not.toBeInTheDocument();
+    });
+
+    it('should call onDelete with correct instanceId on click', () => {
+      const item = createMockItem({ instanceId: 'delete-me-123' });
+      render(
+        <PlacedItemOverlay
+          item={item}
+          gridX={4}
+          gridY={4}
+          isSelected={true}
+          onSelect={mockOnSelect}
+          getItemById={mockGetItemById}
+          onDelete={mockOnDelete}
+        />
+      );
+
+      const deleteBtn = screen.getByRole('button', { name: 'Remove item' });
+      fireEvent.click(deleteBtn);
+
+      expect(mockOnDelete).toHaveBeenCalledWith('delete-me-123');
+      expect(mockOnDelete).toHaveBeenCalledTimes(1);
+    });
+
+    it('should NOT trigger onSelect when delete button is clicked', () => {
+      const item = createMockItem();
+      mockOnSelect.mockClear();
+      render(
+        <PlacedItemOverlay
+          item={item}
+          gridX={4}
+          gridY={4}
+          isSelected={true}
+          onSelect={mockOnSelect}
+          getItemById={mockGetItemById}
+          onDelete={mockOnDelete}
+        />
+      );
+
+      const deleteBtn = screen.getByRole('button', { name: 'Remove item' });
+      fireEvent.click(deleteBtn);
+
+      expect(mockOnSelect).not.toHaveBeenCalled();
+    });
+
+    it('should NOT propagate click to parent', () => {
+      const item = createMockItem();
+      const parentClickHandler = vi.fn();
+      render(
+        <div onClick={parentClickHandler}>
+          <PlacedItemOverlay
+            item={item}
+            gridX={4}
+            gridY={4}
+            isSelected={true}
+            onSelect={mockOnSelect}
+            getItemById={mockGetItemById}
+            onDelete={mockOnDelete}
+          />
+        </div>
+      );
+
+      const deleteBtn = screen.getByRole('button', { name: 'Remove item' });
+      fireEvent.click(deleteBtn);
+
+      expect(parentClickHandler).not.toHaveBeenCalled();
+    });
+
+    it('should have draggable="false" attribute', () => {
+      const item = createMockItem();
+      render(
+        <PlacedItemOverlay
+          item={item}
+          gridX={4}
+          gridY={4}
+          isSelected={true}
+          onSelect={mockOnSelect}
+          getItemById={mockGetItemById}
+          onDelete={mockOnDelete}
+        />
+      );
+
+      const deleteBtn = screen.getByRole('button', { name: 'Remove item' });
+      expect(deleteBtn).toHaveAttribute('draggable', 'false');
+    });
+
+    it('should have aria-label="Remove item"', () => {
+      const item = createMockItem();
+      render(
+        <PlacedItemOverlay
+          item={item}
+          gridX={4}
+          gridY={4}
+          isSelected={true}
+          onSelect={mockOnSelect}
+          getItemById={mockGetItemById}
+          onDelete={mockOnDelete}
+        />
+      );
+
+      const deleteBtn = screen.getByRole('button', { name: 'Remove item' });
+      expect(deleteBtn).toHaveAttribute('aria-label', 'Remove item');
     });
   });
 

--- a/src/components/PlacedItemOverlay.tsx
+++ b/src/components/PlacedItemOverlay.tsx
@@ -8,6 +8,7 @@ interface PlacedItemOverlayProps {
   isSelected: boolean;
   onSelect: (instanceId: string) => void;
   getItemById: (id: string) => LibraryItem | undefined;
+  onDelete?: (instanceId: string) => void;
 }
 
 interface ImageLoadState {
@@ -25,7 +26,7 @@ const getCSSVariable = (varName: string, fallback: string): string => {
 const DEFAULT_VALID_COLOR = getCSSVariable('--grid-primary', '#3B82F6');
 const INVALID_COLOR = getCSSVariable('--invalid-primary', '#EF4444');
 
-export function PlacedItemOverlay({ item, gridX, gridY, isSelected, onSelect, getItemById }: PlacedItemOverlayProps) {
+export function PlacedItemOverlay({ item, gridX, gridY, isSelected, onSelect, getItemById, onDelete }: PlacedItemOverlayProps) {
   const libraryItem = getItemById(item.itemId);
   const color = item.isValid ? (libraryItem?.color || DEFAULT_VALID_COLOR) : INVALID_COLOR;
 
@@ -64,6 +65,12 @@ export function PlacedItemOverlay({ item, gridX, gridY, isSelected, onSelect, ge
     onSelect(item.instanceId);
   };
 
+  const handleDeleteClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+    onDelete?.(item.instanceId);
+  };
+
   return (
     <div
       className={`placed-item ${isSelected ? 'selected' : ''} ${!item.isValid ? 'invalid' : ''}`}
@@ -92,6 +99,19 @@ export function PlacedItemOverlay({ item, gridX, gridY, isSelected, onSelect, ge
         </div>
       )}
       <span className="placed-item-label">{libraryItem?.name}</span>
+      {isSelected && onDelete && (
+        <button
+          className="placed-item-delete-btn"
+          onClick={handleDeleteClick}
+          onMouseDown={(e) => e.stopPropagation()}
+          onPointerDown={(e) => e.stopPropagation()}
+          draggable={false}
+          aria-label="Remove item"
+          title="Remove item"
+        >
+          &times;
+        </button>
+      )}
     </div>
   );
 }

--- a/src/components/ReferenceImageOverlay.test.tsx
+++ b/src/components/ReferenceImageOverlay.test.tsx
@@ -462,7 +462,7 @@ describe('ReferenceImageOverlay', () => {
       expect(mockOnSelect).not.toHaveBeenCalled();
     });
 
-    it('should NOT call onSelect when image is locked', () => {
+    it('should call onSelect when image is locked (allows selecting to unlock)', () => {
       const image = createMockImage({ isLocked: true });
       const { container } = render(
         <ReferenceImageOverlay
@@ -476,7 +476,7 @@ describe('ReferenceImageOverlay', () => {
       const overlayElement = container.querySelector('.reference-image-overlay');
       fireEvent.mouseDown(overlayElement!, { clientX: 100, clientY: 100 });
 
-      expect(mockOnSelect).not.toHaveBeenCalled();
+      expect(mockOnSelect).toHaveBeenCalled();
     });
 
     it('should prevent default and stop propagation on mousedown when interactive and unlocked', () => {

--- a/src/components/ReferenceImageOverlay.tsx
+++ b/src/components/ReferenceImageOverlay.tsx
@@ -40,12 +40,14 @@ export function ReferenceImageOverlay({
   };
 
   const handleMouseDown = (e: React.MouseEvent) => {
-    if (!isInteractive || image.isLocked) return;
+    if (!isInteractive) return;
 
     e.preventDefault();
     e.stopPropagation();
 
     onSelect();
+
+    if (image.isLocked) return;
 
     setDragState({
       isDragging: true,

--- a/src/hooks/useGridItems.test.ts
+++ b/src/hooks/useGridItems.test.ts
@@ -454,6 +454,55 @@ describe('useGridItems', () => {
     });
   });
 
+  describe('clearAll', () => {
+    it('should remove all placed items', () => {
+      const { result } = renderHook(() => useGridItems(4, 4, mockGetItemById));
+
+      act(() => {
+        result.current.addItem('bin-1x1', 0, 0);
+        result.current.addItem('bin-1x1', 1, 0);
+        result.current.addItem('bin-2x2', 2, 2);
+      });
+
+      expect(result.current.placedItems).toHaveLength(3);
+
+      act(() => {
+        result.current.clearAll();
+      });
+
+      expect(result.current.placedItems).toHaveLength(0);
+    });
+
+    it('should clear selection', () => {
+      const { result } = renderHook(() => useGridItems(4, 4, mockGetItemById));
+
+      act(() => {
+        result.current.addItem('bin-1x1', 0, 0);
+      });
+
+      expect(result.current.selectedItemId).not.toBeNull();
+
+      act(() => {
+        result.current.clearAll();
+      });
+
+      expect(result.current.selectedItemId).toBeNull();
+    });
+
+    it('should handle empty state gracefully', () => {
+      const { result } = renderHook(() => useGridItems(4, 4, mockGetItemById));
+
+      expect(result.current.placedItems).toHaveLength(0);
+
+      act(() => {
+        result.current.clearAll();
+      });
+
+      expect(result.current.placedItems).toHaveLength(0);
+      expect(result.current.selectedItemId).toBeNull();
+    });
+  });
+
   describe('Edge Cases', () => {
     it('should handle zero-dimension grid', () => {
       const { result } = renderHook(() => useGridItems(0, 0, mockGetItemById));

--- a/src/hooks/useGridItems.ts
+++ b/src/hooks/useGridItems.ts
@@ -102,6 +102,11 @@ export function useGridItems(
     }
   }, [selectedItemId]);
 
+  const clearAll = useCallback(() => {
+    setPlacedItems([]);
+    setSelectedItemId(null);
+  }, []);
+
   const selectItem = useCallback((instanceId: string | null) => {
     setSelectedItemId(instanceId);
   }, []);
@@ -121,6 +126,7 @@ export function useGridItems(
     moveItem,
     rotateItem,
     deleteItem,
+    clearAll,
     selectItem,
     handleDrop,
   };


### PR DESCRIPTION
## Summary
- Add inline "x" delete button on selected placed items for discoverable in-context deletion
- Add keyboard shortcuts: Delete/Backspace to remove, R to rotate, Escape to deselect
- Add Clear All button with confirmation dialog to remove all placed items
- Fix locked reference image selection (allows selecting locked images to unlock them)
- Add `clearAll` action to `useGridItems` hook

## Test plan
- [x] 8 new unit tests for inline delete button (renders when selected, hides when not, calls onDelete, stopPropagation, aria-label, draggable=false)
- [x] 3 new E2E tests (inline delete removes item, not visible when deselected, removes correct item with multiple items)
- [x] All 510 unit tests pass
- [x] All 56 E2E tests pass
- [x] No new lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)