### PR TITLE
feat: make refresh button also refresh categories

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,7 @@ function App() {
     updateCategory,
     deleteCategory,
     resetToDefaults: resetCategories,
+    refreshCategories,
   } = useCategoryData();
 
   const {
@@ -58,6 +59,7 @@ function App() {
     updateItem,
     deleteItem: deleteLibraryItem,
     resetToDefaults,
+    refreshLibrary,
     updateItemCategories,
     batchUpdateItems,
   } = useLibraryData();
@@ -77,6 +79,24 @@ function App() {
     }
 
     deleteCategory(categoryId);
+  };
+
+  const handleRefreshAll = async () => {
+    // Refresh library items
+    try {
+      await refreshLibrary();
+    } catch (err) {
+      // Error already logged and state set by useLibraryData hook
+      console.error('Library refresh failed:', err);
+    }
+
+    // Refresh categories
+    try {
+      await refreshCategories();
+    } catch (err) {
+      // Error already logged and state set by useCategoryData hook
+      console.error('Categories refresh failed:', err);
+    }
   };
 
   const handleExportLibrary = () => {
@@ -304,6 +324,7 @@ function App() {
             onUpdateItem={updateItem}
             onDeleteItem={deleteLibraryItem}
             onResetToDefaults={resetToDefaults}
+            onRefreshLibrary={handleRefreshAll}
             onExportLibrary={handleExportLibrary}
             onAddCategory={addCategory}
             onUpdateCategory={updateCategory}

--- a/src/components/ItemLibrary.test.tsx
+++ b/src/components/ItemLibrary.test.tsx
@@ -21,6 +21,7 @@ const mockWriteOps = {
   onUpdateItem: vi.fn(),
   onDeleteItem: vi.fn(),
   onResetToDefaults: vi.fn(),
+  onRefreshLibrary: vi.fn().mockResolvedValue(undefined),
   onExportLibrary: vi.fn(),
   onAddCategory: vi.fn(),
   onUpdateCategory: vi.fn(),
@@ -306,6 +307,41 @@ describe('ItemLibrary', () => {
     fireEvent.click(exportButton);
 
     expect(mockWriteOps.onExportLibrary).toHaveBeenCalledTimes(1);
+  });
+
+  it('should render refresh library button', () => {
+    render(<ItemLibrary items={mockLibraryItems} categories={mockCategories} isLoading={false} error={null} {...mockWriteOps} />);
+
+    const refreshButton = screen.getByText('Refresh Library');
+    expect(refreshButton).toBeInTheDocument();
+  });
+
+  it('should call onRefreshLibrary when refresh button is clicked and confirmed', () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    render(<ItemLibrary items={mockLibraryItems} categories={mockCategories} isLoading={false} error={null} {...mockWriteOps} />);
+
+    const refreshButton = screen.getByText('Refresh Library');
+    fireEvent.click(refreshButton);
+
+    expect(window.confirm).toHaveBeenCalledWith('Refresh library and categories from file? All custom changes will be lost.');
+    expect(mockWriteOps.onRefreshLibrary).toHaveBeenCalledTimes(1);
+
+    vi.restoreAllMocks();
+  });
+
+  it('should not call onRefreshLibrary when refresh is cancelled', () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(false);
+
+    render(<ItemLibrary items={mockLibraryItems} categories={mockCategories} isLoading={false} error={null} {...mockWriteOps} />);
+
+    const refreshButton = screen.getByText('Refresh Library');
+    fireEvent.click(refreshButton);
+
+    expect(window.confirm).toHaveBeenCalled();
+    expect(mockWriteOps.onRefreshLibrary).not.toHaveBeenCalled();
+
+    vi.restoreAllMocks();
   });
 
   describe('Category Grouping', () => {

--- a/src/components/ItemLibrary.tsx
+++ b/src/components/ItemLibrary.tsx
@@ -14,6 +14,7 @@ interface ItemLibraryProps {
   onUpdateItem: (id: string, updates: Partial<LibraryItem>) => void;
   onDeleteItem: (id: string) => void;
   onResetToDefaults: () => void;
+  onRefreshLibrary: () => Promise<void>;
   onExportLibrary: () => void;
   onAddCategory: (category: Category) => void;
   onUpdateCategory: (id: string, updates: Partial<Category>) => void;
@@ -32,6 +33,7 @@ export function ItemLibrary({
   onUpdateItem,
   onDeleteItem,
   onResetToDefaults,
+  onRefreshLibrary,
   onExportLibrary,
   onAddCategory,
   onUpdateCategory,
@@ -177,6 +179,18 @@ export function ItemLibrary({
         title="Export library to JSON file"
       >
         Export Library
+      </button>
+
+      <button
+        className="refresh-library-button"
+        onClick={() => {
+          if (window.confirm('Refresh library and categories from file? All custom changes will be lost.')) {
+            onRefreshLibrary();
+          }
+        }}
+        title="Re-fetch library and categories from file, discarding custom changes"
+      >
+        Refresh Library
       </button>
 
       <div className="library-search">


### PR DESCRIPTION
## Summary

Wire up the existing `refreshCategories()` function to the "Refresh Library" button so both library items and categories are refreshed in a single operation.

This provides a complete "reset to defaults" experience - when users click refresh, all custom library items AND custom categories are cleared.

**Note:** Add Basic Bins to Library - future enhancement to be considered

## Changes

- **App.tsx**: Extract `refreshLibrary` and `refreshCategories` from hooks, create `handleRefreshAll()` function that calls both refresh operations sequentially with independent error handling
- **ItemLibrary.tsx**: Add `onRefreshLibrary` prop, implement refresh button with updated confirmation dialog and tooltip
- **ItemLibrary.test.tsx**: Add mock for `onRefreshLibrary`, add tests for render, confirm, and cancel scenarios

## How it works

- Both refresh operations run sequentially, each with its own try-catch
- If one fails, the other still executes (resilient partial success)
- Existing error state management preserved - errors displayed via combined error state
- Loading indicators work naturally via combined loading state

## Test Plan

- [x] All 511 unit tests pass
- [x] Confirmation message shows updated text
- [x] Button has updated tooltip
- [x] Multiple tests cover render, confirm, and cancel scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)