### PR TITLE
fix(selection): placed item click deselection bug

### DIFF
--- a/src/components/PlacedItemOverlay.tsx
+++ b/src/components/PlacedItemOverlay.tsx
@@ -112,6 +112,7 @@ export function PlacedItemOverlay({ item, gridX, gridY, isSelected, onSelect, ge
         touchAction: 'none',
       }}
       onPointerDown={onPointerDown}
+      onClick={(e) => e.stopPropagation()}
     >
       {libraryItem?.imageUrl && !imageError && (
         <div className="placed-item-image-container">


### PR DESCRIPTION
## Summary
- Stop click event propagation on placed items so clicking to select doesn't immediately deselect via the grid container's onClick handler
- Root cause: pointer events (onTap) selected the item, but the click event still bubbled to the grid container which deselected it

## Test plan
- [x] 688 unit tests passing
- [x] 108/109 E2E tests passing (1 pre-existing failure from pointer events rewrite)
- [x] "can select a placed item by clicking on it" test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)