### PR TITLE
chore: clarify gitflow rules — always branch off develop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ e2e/
 - Mock external dependencies, not internal modules
 
 ## Git Workflow
-Always follow gitflow conventions: never commit directly to main. Create feature branches, open PRs, and merge via PR. When committing, verify all changed files are staged before committing (run `git status` to check for unstaged changes). No cherry-picking. **Never delete `main` or `develop` branches (local or remote).**
+Always follow gitflow conventions: never commit directly to main. Create feature branches off `develop`, open PRs to `develop`, and merge via PR. Only merge `develop` into `main` for releases. When committing, verify all changed files are staged before committing (run `git status` to check for unstaged changes). No cherry-picking. **Never delete `main` or `develop` branches (local or remote).** If `develop` is missing, recreate it from `main` before creating any feature branches.
 
 ```bash
 # Create feature branch


### PR DESCRIPTION
## Summary
- Clarify that feature branches must be created off `develop`, not `main`
- Add rule to recreate `develop` from `main` if it is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)