### PR TITLE
feat: add ErrorBoundary to prevent white-screen crashes

### DIFF
--- a/src/components/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ErrorBoundary } from './ErrorBoundary';
+
+function ProblemChild({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) {
+    throw new Error('Test error');
+  }
+  return <div>Child content</div>;
+}
+
+describe('ErrorBoundary', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    // Suppress React's error boundary console output during tests
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  describe('Normal rendering', () => {
+    it('should render children when there is no error', () => {
+      render(
+        <ErrorBoundary>
+          <div>Hello World</div>
+        </ErrorBoundary>
+      );
+      expect(screen.getByText('Hello World')).toBeInTheDocument();
+    });
+
+    it('should not show fallback UI when there is no error', () => {
+      render(
+        <ErrorBoundary>
+          <div>Content</div>
+        </ErrorBoundary>
+      );
+      expect(screen.queryByText('Something went wrong')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Error catching', () => {
+    it('should show fallback UI when a child throws', () => {
+      render(
+        <ErrorBoundary>
+          <ProblemChild shouldThrow={true} />
+        </ErrorBoundary>
+      );
+      expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+    });
+
+    it('should not render children when an error is caught', () => {
+      render(
+        <ErrorBoundary>
+          <ProblemChild shouldThrow={true} />
+        </ErrorBoundary>
+      );
+      expect(screen.queryByText('Child content')).not.toBeInTheDocument();
+    });
+
+    it('should log the error via componentDidCatch', () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      render(
+        <ErrorBoundary>
+          <ProblemChild shouldThrow={true} />
+        </ErrorBoundary>
+      );
+
+      expect(consoleSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('Fallback UI', () => {
+    it('should show a "Reload App" button', () => {
+      render(
+        <ErrorBoundary>
+          <ProblemChild shouldThrow={true} />
+        </ErrorBoundary>
+      );
+      expect(screen.getByRole('button', { name: /reload app/i })).toBeInTheDocument();
+    });
+
+    it('should show a "Try Again" button', () => {
+      render(
+        <ErrorBoundary>
+          <ProblemChild shouldThrow={true} />
+        </ErrorBoundary>
+      );
+      expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
+    });
+
+    it('should show error details when expanded', () => {
+      render(
+        <ErrorBoundary>
+          <ProblemChild shouldThrow={true} />
+        </ErrorBoundary>
+      );
+
+      const details = screen.getByText('Show error details');
+      fireEvent.click(details);
+
+      expect(screen.getByText('Error')).toBeInTheDocument();
+      expect(screen.getByText('Test error')).toBeInTheDocument();
+    });
+
+    it('should mention that data is preserved', () => {
+      render(
+        <ErrorBoundary>
+          <ProblemChild shouldThrow={true} />
+        </ErrorBoundary>
+      );
+      expect(screen.getByText(/data.*preserved/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('Recovery', () => {
+    it('should reset error state and re-render children when "Try Again" is clicked', () => {
+      const { rerender } = render(
+        <ErrorBoundary>
+          <ProblemChild shouldThrow={true} />
+        </ErrorBoundary>
+      );
+
+      expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+
+      // Rerender with a non-throwing child, then click Try Again
+      rerender(
+        <ErrorBoundary>
+          <ProblemChild shouldThrow={false} />
+        </ErrorBoundary>
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /try again/i }));
+
+      expect(screen.getByText('Child content')).toBeInTheDocument();
+      expect(screen.queryByText('Something went wrong')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,46 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { ErrorFallback } from './ErrorFallback';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+  errorInfo: ErrorInfo | null;
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: null, errorInfo: null };
+  }
+
+  static getDerivedStateFromError(error: Error): Partial<ErrorBoundaryState> {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    console.error('ErrorBoundary caught an error:', error, errorInfo);
+    this.setState({ errorInfo });
+  }
+
+  private handleReset = () => {
+    this.setState({ hasError: false, error: null, errorInfo: null });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <ErrorFallback
+          error={this.state.error}
+          errorInfo={this.state.errorInfo}
+          onReset={this.handleReset}
+        />
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/components/ErrorFallback.tsx
+++ b/src/components/ErrorFallback.tsx
@@ -1,0 +1,62 @@
+import { useState } from 'react';
+
+interface ErrorFallbackProps {
+  error: Error | null;
+  errorInfo: React.ErrorInfo | null;
+  onReset: () => void;
+}
+
+export function ErrorFallback({ error, errorInfo, onReset }: ErrorFallbackProps) {
+  const [showDetails, setShowDetails] = useState(false);
+
+  return (
+    <div className="error-fallback">
+      <div className="error-fallback-card">
+        <div className="error-fallback-icon" aria-hidden="true">!</div>
+        <h1 className="error-fallback-title">Something went wrong</h1>
+        <p className="error-fallback-message">
+          An unexpected error occurred. Your data is preserved in local storage.
+        </p>
+
+        <div className="error-fallback-actions">
+          <button className="error-fallback-btn error-fallback-btn-primary" onClick={onReset}>
+            Try Again
+          </button>
+          <button
+            className="error-fallback-btn error-fallback-btn-secondary"
+            onClick={() => window.location.reload()}
+          >
+            Reload App
+          </button>
+        </div>
+
+        <div className="error-fallback-details-section">
+          <button
+            className="error-fallback-details-toggle"
+            onClick={() => setShowDetails(!showDetails)}
+          >
+            {showDetails ? 'Hide error details' : 'Show error details'}
+          </button>
+
+          {showDetails && (
+            <div className="error-fallback-details">
+              {error && (
+                <div className="error-fallback-detail-block">
+                  <h3>Error</h3>
+                  <pre>{error.message}</pre>
+                  {error.stack && <pre className="error-fallback-stack">{error.stack}</pre>}
+                </div>
+              )}
+              {errorInfo?.componentStack && (
+                <div className="error-fallback-detail-block">
+                  <h3>Component Stack</h3>
+                  <pre className="error-fallback-stack">{errorInfo.componentStack}</pre>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -202,3 +202,139 @@ input[type='number']::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
+
+/* Error Boundary Fallback */
+.error-fallback {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  padding: var(--space-xl);
+  background: var(--bg-primary);
+  font-family: var(--font-body);
+}
+
+.error-fallback-card {
+  max-width: 480px;
+  width: 100%;
+  padding: var(--space-2xl);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-lg);
+  text-align: center;
+}
+
+.error-fallback-icon {
+  width: 48px;
+  height: 48px;
+  margin: 0 auto var(--space-lg);
+  border-radius: 50%;
+  background: var(--invalid-bg);
+  color: var(--invalid-primary);
+  font-size: var(--text-xl);
+  font-weight: var(--font-bold);
+  line-height: 48px;
+}
+
+.error-fallback-title {
+  margin: 0 0 var(--space-sm);
+  font-size: var(--text-xl);
+  font-weight: var(--font-semibold);
+  color: var(--text-primary);
+}
+
+.error-fallback-message {
+  margin: 0 0 var(--space-xl);
+  font-size: var(--text-base);
+  color: var(--text-secondary);
+  line-height: var(--leading-relaxed);
+}
+
+.error-fallback-actions {
+  display: flex;
+  gap: var(--space-sm);
+  justify-content: center;
+  margin-bottom: var(--space-xl);
+}
+
+.error-fallback-btn {
+  padding: 0.5em 1.2em;
+  font-size: var(--text-base);
+  font-weight: var(--font-medium);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.error-fallback-btn-primary {
+  background: var(--accent-primary);
+  color: #fff;
+  border: 1px solid var(--accent-primary);
+}
+
+.error-fallback-btn-primary:hover {
+  background: var(--accent-hover);
+  border-color: var(--accent-hover);
+}
+
+.error-fallback-btn-secondary {
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-primary);
+}
+
+.error-fallback-btn-secondary:hover {
+  border-color: var(--blue-500);
+  background: var(--blue-50);
+}
+
+.error-fallback-details-section {
+  border-top: 1px solid var(--border-secondary);
+  padding-top: var(--space-lg);
+}
+
+.error-fallback-details-toggle {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--text-tertiary);
+  font-size: var(--text-sm);
+  cursor: pointer;
+}
+
+.error-fallback-details-toggle:hover {
+  color: var(--text-secondary);
+  background: none;
+  border: none;
+}
+
+.error-fallback-details {
+  margin-top: var(--space-md);
+  text-align: left;
+}
+
+.error-fallback-detail-block h3 {
+  margin: 0 0 var(--space-xs);
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+  color: var(--text-secondary);
+}
+
+.error-fallback-detail-block pre {
+  margin: 0 0 var(--space-md);
+  padding: var(--space-sm);
+  background: var(--bg-tertiary);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-x: auto;
+}
+
+.error-fallback-stack {
+  max-height: 200px;
+  overflow-y: auto;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { ErrorBoundary } from './components/ErrorBoundary'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- Adds an `ErrorBoundary` class component that catches rendering errors and displays a themed fallback UI instead of a white screen
- Fallback includes "Try Again" (resets error state), "Reload App" (full reload), and collapsible error details for debugging
- Wraps `<App />` in `main.tsx` so the entire app is protected

Closes #25

## Test plan
- [x] 10 new unit tests covering normal rendering, error catching, fallback UI, console logging, and recovery
- [x] All 698 unit tests pass
- [x] All 108 E2E tests pass (1 pre-existing flaky collision-detection test excluded)
- [x] ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)