### PR TITLE
feat(shadowbox): overlay uploaded photo behind trace in editor

### DIFF
--- a/packages/app/src/components/ShadowboxEditorPage.tsx
+++ b/packages/app/src/components/ShadowboxEditorPage.tsx
@@ -1,9 +1,10 @@
-import { useState, useRef, useCallback } from 'react';
+import { useState, useRef, useCallback, useEffect } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { generateShadowbox } from '../api/shadowboxes.api';
 import { SHADOWBOXES_QUERY_KEY } from '../hooks/useShadowboxes';
 import { useAuth } from '../contexts/AuthContext';
 import { navigate } from '../utils/navigate';
+import { getPhotoUrl } from '../utils/shadowboxPhotoStore';
 
 interface EditorState {
   shadowboxId: string;
@@ -65,17 +66,43 @@ export function ShadowboxEditorPage() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // Photo overlay
+  const photoUrl = getPhotoUrl();
+  const [showPhoto, setShowPhoto] = useState(photoUrl !== null);
+  const [photoOpacity, setPhotoOpacity] = useState(0.4);
+  const [imageDims, setImageDims] = useState<{ w: number; h: number } | null>(null);
+
+  useEffect(() => {
+    if (!photoUrl) return;
+    const img = new Image();
+    img.onload = () => setImageDims({ w: img.naturalWidth, h: img.naturalHeight });
+    img.src = photoUrl;
+  }, [photoUrl]);
+
   // SVG drag state
   const draggingIndex = useRef<number | null>(null);
   const svgRef = useRef<SVGSVGElement>(null);
 
-  // Compute viewBox from points or fall back to a default
+  // Compute viewBox — expand to include photo if visible
+  const scale = state?.scaleMmPerPx ?? 1;
   const allX = points.map(p => p.x);
   const allY = points.map(p => p.y);
-  const minX = allX.length > 0 ? Math.min(...allX) : -50;
-  const minY = allY.length > 0 ? Math.min(...allY) : -50;
-  const maxX = allX.length > 0 ? Math.max(...allX) : 50;
-  const maxY = allY.length > 0 ? Math.max(...allY) : 50;
+  const traceMinX = allX.length > 0 ? Math.min(...allX) : -50;
+  const traceMinY = allY.length > 0 ? Math.min(...allY) : -50;
+  const traceMaxX = allX.length > 0 ? Math.max(...allX) : 50;
+  const traceMaxY = allY.length > 0 ? Math.max(...allY) : 50;
+
+  const photoW = imageDims ? imageDims.w * scale : 0;
+  const photoH = imageDims ? imageDims.h * scale : 0;
+  const photoMinX = -photoW / 2;
+  const photoMinY = -photoH / 2;
+  const photoMaxX = photoW / 2;
+  const photoMaxY = photoH / 2;
+
+  const minX = showPhoto && imageDims ? Math.min(traceMinX, photoMinX) : traceMinX;
+  const minY = showPhoto && imageDims ? Math.min(traceMinY, photoMinY) : traceMinY;
+  const maxX = showPhoto && imageDims ? Math.max(traceMaxX, photoMaxX) : traceMaxX;
+  const maxY = showPhoto && imageDims ? Math.max(traceMaxY, photoMaxY) : traceMaxY;
   const padding = 10;
   const viewBox = `${minX - padding} ${minY - padding} ${maxX - minX + padding * 2} ${maxY - minY + padding * 2}`;
 
@@ -158,6 +185,17 @@ export function ShadowboxEditorPage() {
         onMouseUp={handleMouseUp}
         onMouseLeave={handleMouseUp}
       >
+        {showPhoto && photoUrl && imageDims && (
+          <image
+            href={photoUrl}
+            x={photoMinX}
+            y={photoMinY}
+            width={photoW}
+            height={photoH}
+            opacity={photoOpacity}
+            preserveAspectRatio="xMidYMid meet"
+          />
+        )}
         {pathD && (
           <path
             d={pathD}
@@ -182,6 +220,34 @@ export function ShadowboxEditorPage() {
       </svg>
 
       <div className="editor-controls">
+        {photoUrl && (
+          <>
+            <div className="form-field form-field--inline">
+              <label htmlFor="show-photo">Show photo</label>
+              <input
+                type="checkbox"
+                id="show-photo"
+                checked={showPhoto}
+                onChange={(e) => setShowPhoto(e.target.checked)}
+              />
+            </div>
+            {showPhoto && (
+              <div className="form-field">
+                <label htmlFor="photo-opacity">Photo opacity ({Math.round(photoOpacity * 100)}%)</label>
+                <input
+                  type="range"
+                  id="photo-opacity"
+                  min="0.1"
+                  max="1.0"
+                  step="0.05"
+                  value={photoOpacity}
+                  onChange={(e) => setPhotoOpacity(Number(e.target.value))}
+                />
+              </div>
+            )}
+          </>
+        )}
+
         <div className="form-field">
           <label htmlFor="tolerance">Tolerance ({tolerance} mm)</label>
           <input

--- a/packages/app/src/components/ShadowboxUploadPage.tsx
+++ b/packages/app/src/components/ShadowboxUploadPage.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { processImage } from '../api/shadowboxes.api';
 import { useAuth } from '../contexts/AuthContext';
 import { navigate } from '../utils/navigate';
+import { setPhotoFile } from '../utils/shadowboxPhotoStore';
 
 export function ShadowboxUploadPage() {
   const { getAccessToken } = useAuth();
@@ -32,6 +33,7 @@ export function ShadowboxUploadPage() {
     setIsSubmitting(true);
     try {
       const result = await processImage(file, thickness, nameInput.value, token);
+      setPhotoFile(file);
       // Store editor state in sessionStorage for the editor page to read
       sessionStorage.setItem(
         `shadowbox-edit-${result.shadowboxId}`,

--- a/packages/app/src/utils/shadowboxPhotoStore.ts
+++ b/packages/app/src/utils/shadowboxPhotoStore.ts
@@ -1,0 +1,18 @@
+/**
+ * Holds the most-recently uploaded shadowbox photo as an object URL so the
+ * editor can display it as a reference overlay without a round-trip to the server.
+ *
+ * The URL is only valid within the same page session (not preserved on refresh),
+ * but that is acceptable — the editor is always reached via client-side navigation
+ * from the upload page.
+ */
+let objectUrl: string | null = null;
+
+export function setPhotoFile(file: File): void {
+  if (objectUrl) URL.revokeObjectURL(objectUrl);
+  objectUrl = URL.createObjectURL(file);
+}
+
+export function getPhotoUrl(): string | null {
+  return objectUrl;
+}


### PR DESCRIPTION
## Summary
- Stores the uploaded photo as an object URL in a lightweight module-level store (`shadowboxPhotoStore`) before navigating to the editor
- Editor reads the URL and renders the photo as an SVG `<image>` element behind the trace polygon, letting users visually verify contour accuracy
- ViewBox expands to encompass the full image when the overlay is visible
- Photo is centered at SVG origin using `scaleMmPerPx`, matching how the contour points are computed

## Controls added
- **Show photo** checkbox — on by default when a photo is available, hidden entirely if navigating directly to the editor URL
- **Opacity slider** — defaults to 40% so the trace remains clearly visible over the image

## Notes
- The photo URL is in-memory only (object URL); it is not persisted to sessionStorage or the server. If the user refreshes `/shadowbox/edit` directly, the overlay won't appear but the SVG trace still loads from sessionStorage normally.

## Test plan
- [ ] Upload a photo → click Process → verify photo appears behind the blue trace in the editor
- [ ] Adjust opacity slider — trace should remain clearly visible at all values
- [ ] Uncheck "Show photo" — image should disappear and viewBox should shrink to trace bounds
- [ ] Navigate to `/shadowbox/edit?id=...` directly (refresh) — no photo overlay, no crash
- [ ] `npm run test:run` — all 1103 tests pass
- [ ] `npm run lint` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)