### PR TITLE
feat(bom-extras): add Extras panel to Order Summary page

### DIFF
--- a/docs/superpowers/plans/2026-04-08-snap-preview-height-bom.md
+++ b/docs/superpowers/plans/2026-04-08-snap-preview-height-bom.md
@@ -1,0 +1,965 @@
+# Snap Preview, Bin Height UI, and BOM Descriptions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a snap preview ghost overlay while dragging bins, upgrade the bin height control to dual unit/mm inputs, and show non-default customizations in the BOM.
+
+**Architecture:** Three independent features. Height UI is a local-state upgrade to `BinCustomizationPanel`. BOM descriptions add a pure utility function consumed by `OrderSummaryPage`. Snap preview threads a new `onSnapChange` callback from `usePointerDrag` → `GridPreview` → `WorkspacePage`, where validity is computed using exported helpers from `useGridItems` and rendered by a new `SnapPreviewOverlay` component.
+
+**Tech Stack:** React 19 + TypeScript, Vitest + React Testing Library (unit), Playwright (E2E)
+
+---
+
+## File Map
+
+| File | Change |
+|---|---|
+| `packages/app/src/components/BinCustomizationPanel.tsx` | Replace height field with dual unit/mm inputs + correction message |
+| `packages/app/src/components/BinCustomizationPanel.test.tsx` | Update/add height field tests |
+| `packages/app/src/utils/customizationDescription.ts` | New — `formatCustomizationDescription` utility |
+| `packages/app/src/utils/customizationDescription.test.ts` | New — unit tests for above |
+| `packages/app/src/pages/OrderSummaryPage.tsx` | Render customization description below item name |
+| `packages/app/src/hooks/useGridItems.ts` | Export `hasCollision` and `isOutOfBounds` |
+| `packages/app/src/hooks/usePointerDrag.ts` | Add `onSnapChange` to `DropTargetConfig` + `PointerDropTargetOptions`; call during drag |
+| `packages/app/src/components/SnapPreviewOverlay.tsx` | New — renders ghost preview div |
+| `packages/app/src/components/GridPreview.tsx` | Add `snapPreview` + `onSnapChange` props; render `SnapPreviewOverlay` |
+| `packages/app/src/components/GridPreview.test.tsx` | Add snap preview rendering tests |
+| `packages/app/src/pages/WorkspacePage.tsx` | Add `rawSnapPreview` state, compute `snapPreview`, pass to `GridPreview` |
+| `packages/app/src/index.css` | Add `.snap-preview--valid` and `.snap-preview--invalid` styles |
+
+---
+
+## Task 1: Bin Height UI — update tests
+
+**Files:**
+- Modify: `packages/app/src/components/BinCustomizationPanel.test.tsx`
+
+- [ ] **Step 1: Update the existing height field tests to match the new UI**
+
+Replace the existing `describe('height field', ...)` block (around line 664) with:
+
+```ts
+describe('height field', () => {
+  it('renders unit and mm inputs', () => {
+    render(
+      <BinCustomizationPanel
+        customization={DEFAULT_BIN_CUSTOMIZATION}
+        onChange={mockOnChange}
+        onReset={mockOnReset}
+        customizableFields={['height']}
+      />
+    );
+    expect(screen.getByLabelText('Height in units')).toBeInTheDocument();
+    expect(screen.getByLabelText('Height in millimeters')).toBeInTheDocument();
+  });
+
+  it('unit input shows current height, mm input shows height * 7', () => {
+    render(
+      <BinCustomizationPanel
+        customization={{ ...DEFAULT_BIN_CUSTOMIZATION, height: 3 }}
+        onChange={mockOnChange}
+        onReset={mockOnReset}
+        customizableFields={['height']}
+      />
+    );
+    expect(screen.getByLabelText('Height in units')).toHaveValue(3);
+    expect(screen.getByLabelText('Height in millimeters')).toHaveValue(21);
+  });
+
+  it('changing unit input calls onChange with new height', () => {
+    render(
+      <BinCustomizationPanel
+        customization={DEFAULT_BIN_CUSTOMIZATION}
+        onChange={mockOnChange}
+        onReset={mockOnReset}
+        customizableFields={['height']}
+      />
+    );
+    fireEvent.change(screen.getByLabelText('Height in units'), { target: { value: '5' } });
+    expect(mockOnChange).toHaveBeenCalledWith(expect.objectContaining({ height: 5 }));
+  });
+
+  it('blurring mm input with aligned value calls onChange with correct units', () => {
+    render(
+      <BinCustomizationPanel
+        customization={DEFAULT_BIN_CUSTOMIZATION}
+        onChange={mockOnChange}
+        onReset={mockOnReset}
+        customizableFields={['height']}
+      />
+    );
+    fireEvent.change(screen.getByLabelText('Height in millimeters'), { target: { value: '28' } });
+    fireEvent.blur(screen.getByLabelText('Height in millimeters'));
+    expect(mockOnChange).toHaveBeenCalledWith(expect.objectContaining({ height: 4 }));
+  });
+
+  it('blurring mm input with unaligned value rounds down and shows correction message', async () => {
+    render(
+      <BinCustomizationPanel
+        customization={DEFAULT_BIN_CUSTOMIZATION}
+        onChange={mockOnChange}
+        onReset={mockOnReset}
+        customizableFields={['height']}
+      />
+    );
+    fireEvent.change(screen.getByLabelText('Height in millimeters'), { target: { value: '23' } });
+    fireEvent.blur(screen.getByLabelText('Height in millimeters'));
+    expect(mockOnChange).toHaveBeenCalledWith(expect.objectContaining({ height: 3 }));
+    expect(await screen.findByText(/rounded to 3u \(21mm\)/i)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run height tests — confirm they FAIL**
+
+```bash
+cd .worktrees/feat/snap-preview-height-bom
+npx vitest run packages/app/src/components/BinCustomizationPanel.test.tsx 2>&1 | tail -20
+```
+
+Expected: failures on height field tests (old UI doesn't have the new aria-labels).
+
+---
+
+## Task 2: Bin Height UI — implement dual inputs
+
+**Files:**
+- Modify: `packages/app/src/components/BinCustomizationPanel.tsx`
+
+- [ ] **Step 1: Replace the height field block with dual inputs**
+
+Add `useState` and `useRef` imports at the top:
+```ts
+import { useState, useRef } from 'react';
+```
+
+Replace the `{has('height') && (...)}` block (currently around line 103) with:
+
+```tsx
+{has('height') && (
+  <HeightField
+    height={current.height}
+    idPrefix={idPrefix}
+    onChange={(h) => onChange({ ...current, height: h })}
+  />
+)}
+```
+
+Add the `HeightField` component above `BinCustomizationPanel` in the same file:
+
+```tsx
+interface HeightFieldProps {
+  height: number;
+  idPrefix: string;
+  onChange: (height: number) => void;
+}
+
+function HeightField({ height, idPrefix, onChange }: HeightFieldProps) {
+  const [mmEditValue, setMmEditValue] = useState<string | null>(null);
+  const [correctionMsg, setCorrectionMsg] = useState<string | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const displayedMm = mmEditValue ?? String(height * 7);
+
+  const handleUnitChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const v = parseInt(e.target.value, 10);
+    if (!isNaN(v) && v >= 1 && v <= 20) {
+      onChange(v);
+    }
+  };
+
+  const handleMmChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setMmEditValue(e.target.value);
+  };
+
+  const handleMmBlur = () => {
+    const raw = parseInt(mmEditValue ?? '', 10);
+    setMmEditValue(null);
+    if (isNaN(raw) || raw < 7) return;
+    const units = Math.floor(raw / 7);
+    const snapped = units * 7;
+    if (snapped !== raw) {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      setCorrectionMsg(`Rounded to ${units}u (${snapped}mm)`);
+      timerRef.current = setTimeout(() => setCorrectionMsg(null), 2000);
+    }
+    if (units >= 1 && units <= 20) {
+      onChange(units);
+    }
+  };
+
+  return (
+    <div className="bin-customization-field">
+      <label>Height</label>
+      <div className="height-inputs">
+        <input
+          id={`${idPrefix}height-units-input`}
+          aria-label="Height in units"
+          type="number"
+          min={1}
+          max={20}
+          value={height}
+          onChange={handleUnitChange}
+        />
+        <span>u</span>
+        <input
+          id={`${idPrefix}height-mm-input`}
+          aria-label="Height in millimeters"
+          type="number"
+          min={7}
+          value={displayedMm}
+          onChange={handleMmChange}
+          onBlur={handleMmBlur}
+        />
+        <span>mm</span>
+      </div>
+      {correctionMsg && (
+        <div className="height-correction" role="status">{correctionMsg}</div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Run height tests — all must pass**
+
+```bash
+npx vitest run packages/app/src/components/BinCustomizationPanel.test.tsx 2>&1 | tail -20
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Run full unit suite to check for regressions**
+
+```bash
+npm run test:run 2>&1 | tail -10
+```
+
+Expected: all 1150 app + 220 server tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/app/src/components/BinCustomizationPanel.tsx \
+        packages/app/src/components/BinCustomizationPanel.test.tsx
+git commit -m "feat(customization): dual unit/mm height inputs with rounding correction"
+```
+
+---
+
+## Task 3: BOM Descriptions — utility and tests
+
+**Files:**
+- Create: `packages/app/src/utils/customizationDescription.ts`
+- Create: `packages/app/src/utils/customizationDescription.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/app/src/utils/customizationDescription.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { formatCustomizationDescription } from './customizationDescription';
+import { DEFAULT_BIN_CUSTOMIZATION } from '../types/gridfinity';
+
+describe('formatCustomizationDescription', () => {
+  it('returns empty string for default customization', () => {
+    expect(formatCustomizationDescription(DEFAULT_BIN_CUSTOMIZATION)).toBe('');
+  });
+
+  it('returns empty string when all fields are default', () => {
+    expect(formatCustomizationDescription({ ...DEFAULT_BIN_CUSTOMIZATION })).toBe('');
+  });
+
+  it('formats non-default wall pattern', () => {
+    expect(formatCustomizationDescription({ ...DEFAULT_BIN_CUSTOMIZATION, wallPattern: 'hexgrid' }))
+      .toBe('Hex Wall');
+  });
+
+  it('formats non-default lip style', () => {
+    expect(formatCustomizationDescription({ ...DEFAULT_BIN_CUSTOMIZATION, lipStyle: 'reduced' }))
+      .toBe('Reduced Lip');
+  });
+
+  it('formats non-default finger slide', () => {
+    expect(formatCustomizationDescription({ ...DEFAULT_BIN_CUSTOMIZATION, fingerSlide: 'chamfered' }))
+      .toBe('Chamfered Finger Slide');
+  });
+
+  it('formats non-default wall cutout', () => {
+    expect(formatCustomizationDescription({ ...DEFAULT_BIN_CUSTOMIZATION, wallCutout: 'both' }))
+      .toBe('Full Cutout');
+  });
+
+  it('formats non-default height', () => {
+    expect(formatCustomizationDescription({ ...DEFAULT_BIN_CUSTOMIZATION, height: 3 }))
+      .toBe('3u height');
+  });
+
+  it('joins multiple non-default fields with ·', () => {
+    expect(formatCustomizationDescription({
+      wallPattern: 'hexgrid',
+      lipStyle: 'reduced',
+      fingerSlide: 'none',
+      wallCutout: 'none',
+      height: 3,
+    })).toBe('Hex Wall · Reduced Lip · 3u height');
+  });
+
+  it('handles all wall pattern values', () => {
+    expect(formatCustomizationDescription({ ...DEFAULT_BIN_CUSTOMIZATION, wallPattern: 'grid' })).toBe('Grid Wall');
+    expect(formatCustomizationDescription({ ...DEFAULT_BIN_CUSTOMIZATION, wallPattern: 'voronoi' })).toBe('Voronoi Wall');
+    expect(formatCustomizationDescription({ ...DEFAULT_BIN_CUSTOMIZATION, wallPattern: 'voronoigrid' })).toBe('Voronoi Grid Wall');
+    expect(formatCustomizationDescription({ ...DEFAULT_BIN_CUSTOMIZATION, wallPattern: 'voronoihexgrid' })).toBe('Voronoi Hex Wall');
+  });
+
+  it('handles all lip style values', () => {
+    expect(formatCustomizationDescription({ ...DEFAULT_BIN_CUSTOMIZATION, lipStyle: 'minimum' })).toBe('Minimum Lip');
+    expect(formatCustomizationDescription({ ...DEFAULT_BIN_CUSTOMIZATION, lipStyle: 'none' })).toBe('No Lip');
+  });
+
+  it('handles all wall cutout values', () => {
+    expect(formatCustomizationDescription({ ...DEFAULT_BIN_CUSTOMIZATION, wallCutout: 'vertical' })).toBe('Vertical Cutout');
+    expect(formatCustomizationDescription({ ...DEFAULT_BIN_CUSTOMIZATION, wallCutout: 'horizontal' })).toBe('Horizontal Cutout');
+  });
+
+  it('handles rounded finger slide', () => {
+    expect(formatCustomizationDescription({ ...DEFAULT_BIN_CUSTOMIZATION, fingerSlide: 'rounded' })).toBe('Rounded Finger Slide');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — confirm they FAIL**
+
+```bash
+npx vitest run packages/app/src/utils/customizationDescription.test.ts 2>&1 | tail -10
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Create the utility**
+
+Create `packages/app/src/utils/customizationDescription.ts`:
+
+```ts
+import type { BinCustomization } from '../types/gridfinity';
+import { DEFAULT_BIN_CUSTOMIZATION } from '../types/gridfinity';
+
+const WALL_PATTERN_LABELS: Record<string, string> = {
+  grid: 'Grid Wall',
+  hexgrid: 'Hex Wall',
+  voronoi: 'Voronoi Wall',
+  voronoigrid: 'Voronoi Grid Wall',
+  voronoihexgrid: 'Voronoi Hex Wall',
+};
+
+const LIP_STYLE_LABELS: Record<string, string> = {
+  reduced: 'Reduced Lip',
+  minimum: 'Minimum Lip',
+  none: 'No Lip',
+};
+
+const FINGER_SLIDE_LABELS: Record<string, string> = {
+  rounded: 'Rounded Finger Slide',
+  chamfered: 'Chamfered Finger Slide',
+};
+
+const WALL_CUTOUT_LABELS: Record<string, string> = {
+  vertical: 'Vertical Cutout',
+  horizontal: 'Horizontal Cutout',
+  both: 'Full Cutout',
+};
+
+export function formatCustomizationDescription(c: BinCustomization): string {
+  const parts: string[] = [];
+  if (c.wallPattern !== DEFAULT_BIN_CUSTOMIZATION.wallPattern) {
+    parts.push(WALL_PATTERN_LABELS[c.wallPattern] ?? c.wallPattern);
+  }
+  if (c.lipStyle !== DEFAULT_BIN_CUSTOMIZATION.lipStyle) {
+    parts.push(LIP_STYLE_LABELS[c.lipStyle] ?? c.lipStyle);
+  }
+  if (c.fingerSlide !== DEFAULT_BIN_CUSTOMIZATION.fingerSlide) {
+    parts.push(FINGER_SLIDE_LABELS[c.fingerSlide] ?? c.fingerSlide);
+  }
+  if (c.wallCutout !== DEFAULT_BIN_CUSTOMIZATION.wallCutout) {
+    parts.push(WALL_CUTOUT_LABELS[c.wallCutout] ?? c.wallCutout);
+  }
+  if (c.height !== DEFAULT_BIN_CUSTOMIZATION.height) {
+    parts.push(`${c.height}u height`);
+  }
+  return parts.join(' · ');
+}
+```
+
+- [ ] **Step 4: Run tests — all must pass**
+
+```bash
+npx vitest run packages/app/src/utils/customizationDescription.test.ts 2>&1 | tail -10
+```
+
+Expected: all 14 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/app/src/utils/customizationDescription.ts \
+        packages/app/src/utils/customizationDescription.test.ts
+git commit -m "feat(bom): add formatCustomizationDescription utility"
+```
+
+---
+
+## Task 4: BOM Descriptions — render in OrderSummaryPage
+
+**Files:**
+- Modify: `packages/app/src/pages/OrderSummaryPage.tsx`
+
+- [ ] **Step 1: Add the import and render the description**
+
+Add import at the top of `OrderSummaryPage.tsx`:
+```ts
+import { formatCustomizationDescription } from '../utils/customizationDescription';
+```
+
+Inside the BOM table row, replace the name cell:
+```tsx
+// BEFORE:
+<div>
+  <div className="order-bom-name">{item.name}</div>
+</div>
+
+// AFTER:
+<div>
+  <div className="order-bom-name">{item.name}</div>
+  {item.customization && (() => {
+    const desc = formatCustomizationDescription(item.customization);
+    return desc ? <div className="order-bom-description">{desc}</div> : null;
+  })()}
+</div>
+```
+
+Add to `packages/app/src/pages/OrderSummaryPage.css` (or wherever the page styles live — check the import at the top of the file):
+```css
+.order-bom-description {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  margin-top: 2px;
+}
+```
+
+- [ ] **Step 2: Run full unit suite**
+
+```bash
+npm run test:run 2>&1 | tail -10
+```
+
+Expected: all tests pass (no snapshot or rendering tests reference this cell).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/app/src/pages/OrderSummaryPage.tsx \
+        packages/app/src/pages/OrderSummaryPage.css
+git commit -m "feat(bom): show non-default customizations as description in order summary"
+```
+
+---
+
+## Task 5: Snap Preview — export collision helpers
+
+**Files:**
+- Modify: `packages/app/src/hooks/useGridItems.ts`
+
+- [ ] **Step 1: Export `hasCollision` and `isOutOfBounds`**
+
+In `useGridItems.ts`, change the function declarations from `function hasCollision(` and `function isOutOfBounds(` to `export function hasCollision(` and `export function isOutOfBounds(`. These are pure utility functions with no React dependencies.
+
+```ts
+// line ~32 — change to:
+export function hasCollision(
+  items: PlacedItem[],
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  excludeId?: string
+): boolean {
+
+// line ~72 — change to:
+export function isOutOfBounds(
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  gridX: number,
+  gridY: number
+): boolean {
+```
+
+- [ ] **Step 2: Run full unit suite — no regressions**
+
+```bash
+npm run test:run 2>&1 | tail -10
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/app/src/hooks/useGridItems.ts
+git commit -m "refactor(grid): export hasCollision and isOutOfBounds for reuse"
+```
+
+---
+
+## Task 6: Snap Preview — add onSnapChange to drag system
+
+**Files:**
+- Modify: `packages/app/src/hooks/usePointerDrag.ts`
+
+- [ ] **Step 1: Define the SnapPreview type and add onSnapChange to DropTargetConfig**
+
+At the top of `usePointerDrag.ts`, after the imports, add:
+
+```ts
+export interface SnapPreviewData {
+  dragData: DragData;
+  col: number;
+  row: number;
+}
+```
+
+In the `DropTargetConfig` interface, add:
+```ts
+interface DropTargetConfig {
+  element: HTMLElement;
+  gridX: number;
+  gridY: number;
+  onDrop: (dragData: DragData, x: number, y: number) => void;
+  onSnapChange?: (preview: SnapPreviewData | null) => void;
+}
+```
+
+In the `PointerDropTargetOptions` interface, add:
+```ts
+interface PointerDropTargetOptions {
+  gridRef: React.RefObject<HTMLDivElement | null>;
+  gridX: number;
+  gridY: number;
+  onDrop: (dragData: DragData, x: number, y: number) => void;
+  onSnapChange?: (preview: SnapPreviewData | null) => void;
+}
+```
+
+In `registerDropTarget` and `usePointerDropTarget`, pass `onSnapChange` through:
+```ts
+// in usePointerDropTarget:
+export function usePointerDropTarget(options: PointerDropTargetOptions): void {
+  const { gridRef, gridX, gridY, onDrop, onSnapChange } = options;
+
+  useEffect(() => {
+    const el = gridRef.current;
+    if (!el || gridX <= 0 || gridY <= 0) return;
+    registerDropTarget({ element: el, gridX, gridY, onDrop, onSnapChange });
+    return () => unregisterDropTarget();
+  }, [gridRef, gridX, gridY, onDrop, onSnapChange]);
+}
+```
+
+- [ ] **Step 2: Call onSnapChange during pointermove**
+
+Inside the `handlePointerMove` function in `usePointerDragSource`, after the ghost element is moved, add:
+
+```ts
+// After the ghost move block:
+if (isDragging && dragStore.dropTarget) {
+  const { element, gridX: tgX, gridY: tgY, onSnapChange } = dragStore.dropTarget;
+  const rect = element.getBoundingClientRect();
+  if (
+    moveEvent.clientX >= rect.left && moveEvent.clientX <= rect.right &&
+    moveEvent.clientY >= rect.top && moveEvent.clientY <= rect.bottom
+  ) {
+    const cellWidth = rect.width / tgX;
+    const cellHeight = rect.height / tgY;
+    const col = Math.max(0, Math.min(Math.floor((moveEvent.clientX - rect.left) / cellWidth), tgX - 1));
+    const row = Math.max(0, Math.min(Math.floor((moveEvent.clientY - rect.top) / cellHeight), tgY - 1));
+    onSnapChange?.({ dragData: dragStore.activeDrag!.data, col, row });
+  } else {
+    onSnapChange?.(null);
+  }
+}
+```
+
+- [ ] **Step 3: Clear snap preview on drag end and cancel**
+
+In `handlePointerUp` (inside the `isDragging` branch), before `attemptDrop`:
+```ts
+dragStore.dropTarget?.onSnapChange?.(null);
+```
+
+In `handlePointerCancel`, before `clearActiveDrag()`:
+```ts
+dragStore.dropTarget?.onSnapChange?.(null);
+```
+
+- [ ] **Step 4: Run full unit suite — no regressions**
+
+```bash
+npm run test:run 2>&1 | tail -10
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/app/src/hooks/usePointerDrag.ts
+git commit -m "feat(drag): emit onSnapChange with current snap cell during drag"
+```
+
+---
+
+## Task 7: Snap Preview — SnapPreviewOverlay component
+
+**Files:**
+- Create: `packages/app/src/components/SnapPreviewOverlay.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/app/src/components/SnapPreviewOverlay.test.tsx`:
+
+```tsx
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { SnapPreviewOverlay } from './SnapPreviewOverlay';
+
+describe('SnapPreviewOverlay', () => {
+  it('renders with valid class when valid', () => {
+    const { container } = render(
+      <SnapPreviewOverlay col={1} row={0} w={2} d={1} valid={true} gridX={4} gridY={4} />
+    );
+    expect(container.firstChild).toHaveClass('snap-preview--valid');
+  });
+
+  it('renders with invalid class when not valid', () => {
+    const { container } = render(
+      <SnapPreviewOverlay col={0} row={0} w={2} d={1} valid={false} gridX={4} gridY={4} />
+    );
+    expect(container.firstChild).toHaveClass('snap-preview--invalid');
+  });
+
+  it('positions correctly using percentage-based styles', () => {
+    const { container } = render(
+      <SnapPreviewOverlay col={1} row={2} w={2} d={1} valid={true} gridX={4} gridY={4} />
+    );
+    const el = container.firstChild as HTMLElement;
+    expect(el.style.left).toBe('25%');
+    expect(el.style.top).toBe('50%');
+    expect(el.style.width).toBe('50%');
+    expect(el.style.height).toBe('25%');
+  });
+
+  it('is hidden from assistive technology', () => {
+    const { container } = render(
+      <SnapPreviewOverlay col={0} row={0} w={1} d={1} valid={true} gridX={4} gridY={4} />
+    );
+    expect(container.firstChild).toHaveAttribute('aria-hidden', 'true');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — confirm they FAIL**
+
+```bash
+npx vitest run packages/app/src/components/SnapPreviewOverlay.test.tsx 2>&1 | tail -10
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Create the component**
+
+Create `packages/app/src/components/SnapPreviewOverlay.tsx`:
+
+```tsx
+interface SnapPreviewOverlayProps {
+  col: number;
+  row: number;
+  w: number;
+  d: number;
+  valid: boolean;
+  gridX: number;
+  gridY: number;
+}
+
+export function SnapPreviewOverlay({ col, row, w, d, valid, gridX, gridY }: SnapPreviewOverlayProps) {
+  return (
+    <div
+      className={`snap-preview ${valid ? 'snap-preview--valid' : 'snap-preview--invalid'}`}
+      style={{
+        position: 'absolute',
+        left: `${(col / gridX) * 100}%`,
+        top: `${(row / gridY) * 100}%`,
+        width: `${(w / gridX) * 100}%`,
+        height: `${(d / gridY) * 100}%`,
+        pointerEvents: 'none',
+        zIndex: 1,
+      }}
+      aria-hidden="true"
+    />
+  );
+}
+```
+
+- [ ] **Step 4: Run SnapPreviewOverlay tests — all pass**
+
+```bash
+npx vitest run packages/app/src/components/SnapPreviewOverlay.test.tsx 2>&1 | tail -10
+```
+
+Expected: 4 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/app/src/components/SnapPreviewOverlay.tsx \
+        packages/app/src/components/SnapPreviewOverlay.test.tsx
+git commit -m "feat(grid): add SnapPreviewOverlay component"
+```
+
+---
+
+## Task 8: Snap Preview — wire into GridPreview
+
+**Files:**
+- Modify: `packages/app/src/components/GridPreview.tsx`
+- Modify: `packages/app/src/components/GridPreview.test.tsx`
+
+- [ ] **Step 1: Add failing tests to GridPreview.test.tsx**
+
+Add a new `describe('Snap Preview', ...)` block near the end of the existing GridPreview test file:
+
+```tsx
+describe('Snap Preview', () => {
+  const baseProps = {
+    gridX: 4,
+    gridY: 4,
+    placedItems: [],
+    selectedItemIds: new Set<string>(),
+    onDrop: vi.fn(),
+    onSelectItem: vi.fn(),
+    getItemById: vi.fn(),
+  };
+
+  it('renders no snap preview when snapPreview is null', () => {
+    const { container } = render(<GridPreview {...baseProps} snapPreview={null} />);
+    expect(container.querySelector('.snap-preview')).toBeNull();
+  });
+
+  it('renders valid snap preview overlay', () => {
+    const { container } = render(
+      <GridPreview
+        {...baseProps}
+        snapPreview={{ col: 1, row: 0, w: 2, d: 1, valid: true }}
+      />
+    );
+    expect(container.querySelector('.snap-preview--valid')).toBeInTheDocument();
+  });
+
+  it('renders invalid snap preview overlay', () => {
+    const { container } = render(
+      <GridPreview
+        {...baseProps}
+        snapPreview={{ col: 0, row: 0, w: 2, d: 1, valid: false }}
+      />
+    );
+    expect(container.querySelector('.snap-preview--invalid')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — confirm the new ones FAIL**
+
+```bash
+npx vitest run packages/app/src/components/GridPreview.test.tsx 2>&1 | tail -15
+```
+
+Expected: new snap preview tests fail.
+
+- [ ] **Step 3: Update GridPreview to accept snapPreview and onSnapChange**
+
+In `GridPreviewProps`, add:
+```ts
+snapPreview?: { col: number; row: number; w: number; d: number; valid: boolean } | null;
+onSnapChange?: (preview: import('../hooks/usePointerDrag').SnapPreviewData | null) => void;
+```
+
+Add to destructured props:
+```ts
+snapPreview = null,
+onSnapChange,
+```
+
+Update `usePointerDropTarget` call to pass `onSnapChange`:
+```ts
+usePointerDropTarget({
+  gridRef,
+  gridX,
+  gridY,
+  onDrop,
+  onSnapChange,
+});
+```
+
+Add the import at the top:
+```ts
+import { SnapPreviewOverlay } from './SnapPreviewOverlay';
+import type { SnapPreviewData } from '../hooks/usePointerDrag';
+```
+
+Inside the `.grid-container` div, after `{cells}` and before `{placedItems.map(...)}`, add:
+```tsx
+{snapPreview && (
+  <SnapPreviewOverlay
+    col={snapPreview.col}
+    row={snapPreview.row}
+    w={snapPreview.w}
+    d={snapPreview.d}
+    valid={snapPreview.valid}
+    gridX={gridX}
+    gridY={gridY}
+  />
+)}
+```
+
+- [ ] **Step 4: Run GridPreview tests — all pass**
+
+```bash
+npx vitest run packages/app/src/components/GridPreview.test.tsx 2>&1 | tail -15
+```
+
+Expected: all tests pass including new snap preview tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/app/src/components/GridPreview.tsx \
+        packages/app/src/components/GridPreview.test.tsx
+git commit -m "feat(grid): render SnapPreviewOverlay when snapPreview prop is set"
+```
+
+---
+
+## Task 9: Snap Preview — wire WorkspacePage + CSS
+
+**Files:**
+- Modify: `packages/app/src/pages/WorkspacePage.tsx`
+- Modify: `packages/app/src/index.css`
+
+- [ ] **Step 1: Add snap state and computed snapPreview to WorkspacePage**
+
+Add imports:
+```ts
+import { useState, useCallback, useMemo } from 'react'; // useMemo may already be imported
+import { hasCollision, isOutOfBounds } from '../hooks/useGridItems';
+import type { SnapPreviewData } from '../hooks/usePointerDrag';
+```
+
+After the existing `handleCombinedDrop` callback, add:
+
+```ts
+const [rawSnapPreview, setRawSnapPreview] = useState<SnapPreviewData | null>(null);
+
+const snapPreview = useMemo(() => {
+  if (!rawSnapPreview) return null;
+  const { dragData, col, row } = rawSnapPreview;
+  if (dragData.type === 'ref-image') return null;
+
+  let w: number, d: number, excludeId: string | undefined;
+
+  if (dragData.type === 'library') {
+    const item = getItemById(dragData.itemId);
+    if (!item) return null;
+    w = item.widthUnits;
+    d = item.heightUnits;
+  } else if (dragData.type === 'placed' && dragData.instanceId) {
+    const placed = placedItems.find(i => i.instanceId === dragData.instanceId);
+    if (!placed) return null;
+    w = placed.width;
+    d = placed.height;
+    excludeId = dragData.instanceId;
+  } else {
+    return null;
+  }
+
+  const oob = isOutOfBounds(col, row, w, d, gridResult.gridX, gridResult.gridY);
+  const collides = !oob && hasCollision(placedItems, col, row, w, d, excludeId);
+  return { col, row, w, d, valid: !oob && !collides };
+}, [rawSnapPreview, placedItems, getItemById, gridResult.gridX, gridResult.gridY]);
+```
+
+- [ ] **Step 2: Pass snapPreview and onSnapChange to GridPreview**
+
+In the `<GridPreview ... />` JSX, add the two new props:
+```tsx
+snapPreview={snapPreview}
+onSnapChange={setRawSnapPreview}
+```
+
+- [ ] **Step 3: Add CSS for snap preview**
+
+In `packages/app/src/index.css`, add:
+
+```css
+.snap-preview--valid {
+  background: rgba(59, 130, 246, 0.2);
+  border: 2px dashed #3b82f6;
+  border-radius: 2px;
+  box-sizing: border-box;
+}
+
+.snap-preview--invalid {
+  background: rgba(239, 68, 68, 0.2);
+  border: 2px dashed #ef4444;
+  border-radius: 2px;
+  box-sizing: border-box;
+}
+```
+
+- [ ] **Step 4: Run full unit suite**
+
+```bash
+npm run test:run 2>&1 | tail -10
+```
+
+Expected: all 1150 app + 220 server tests pass.
+
+- [ ] **Step 5: Run linter**
+
+```bash
+npm run lint 2>&1 | tail -20
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/app/src/pages/WorkspacePage.tsx \
+        packages/app/src/index.css
+git commit -m "feat(grid): wire snap preview into WorkspacePage with validity check"
+```
+
+---
+
+## Task 10: Final verification
+
+- [ ] **Step 1: Run full test suite**
+
+```bash
+npm run test:run && npm run test:e2e 2>&1 | tail -20
+```
+
+Expected: all 1150 app + 220 server unit tests pass, all 142 E2E tests pass.
+
+- [ ] **Step 2: Done — ready for PR**

--- a/packages/app/src/contexts/WorkspaceContext.tsx
+++ b/packages/app/src/contexts/WorkspaceContext.tsx
@@ -4,7 +4,7 @@ import type {
   UnitSystem, ImperialFormat, GridSpacerConfig, BOMItem, LibraryItem,
   LibraryMeta, DragData, BinCustomization, Category,
   GridResult, ReferenceImage, PlacedItem, PlacedItemWithValidity,
-  ComputedSpacer,
+  ComputedSpacer, BOMExtras,
 } from '../types/gridfinity';
 import type { SelectModifiers } from '../hooks/useGridItems';
 import type { LoadedLayoutConfig } from '../types/layoutConfig';
@@ -18,6 +18,7 @@ import { useDialogState } from '../hooks/useDialogState';
 import { useGridItems } from '../hooks/useGridItems';
 import { useSpacerCalculation } from '../hooks/useSpacerCalculation';
 import { useBillOfMaterials } from '../hooks/useBillOfMaterials';
+import { useBOMExtras } from '../hooks/useBOMExtras';
 import { useLibraries } from '../hooks/useLibraries';
 import { useLibraryData } from '../hooks/useLibraryData';
 import { useCategoryData } from '../hooks/useCategoryData';
@@ -91,6 +92,13 @@ interface WorkspaceContextValue {
 
   // BOM
   bomItems: BOMItem[];
+
+  // BOM extras
+  extras: BOMExtras;
+  addExtra: (key: string) => void;
+  setExtraQty: (key: string, qty: number) => void;
+  removeExtra: (key: string) => void;
+  clearExtras: () => void;
 
   // Layout meta
   layoutMeta: LayoutMetaState;
@@ -292,6 +300,7 @@ export function WorkspaceProvider({ children }: WorkspaceProviderProps) {
   } = useGridItems(gridResult.gridX, gridResult.gridY, getItemById);
 
   const bomItems = useBillOfMaterials(placedItems, libraryItems);
+  const { extras, addExtra, setExtraQty, removeExtra, clearExtras } = useBOMExtras();
 
   // Load library meta for the selected single item
   useEffect(() => {
@@ -349,6 +358,7 @@ export function WorkspaceProvider({ children }: WorkspaceProviderProps) {
   const { handleLoadLayout, loadLayout } = useLayoutLoader({
     unitSystem, setWidth, setDepth, setSpacerConfig,
     loadItems, loadRefImagePlacements, layoutDispatch, getAccessToken,
+    clearExtras,
   });
 
   // handleClearAll: confirms then clears items and ref images
@@ -418,6 +428,13 @@ export function WorkspaceProvider({ children }: WorkspaceProviderProps) {
 
     // BOM
     bomItems,
+
+    // BOM extras
+    extras,
+    addExtra,
+    setExtraQty,
+    removeExtra,
+    clearExtras,
 
     // Layout meta
     layoutMeta,

--- a/packages/app/src/hooks/useBOMExtras.test.ts
+++ b/packages/app/src/hooks/useBOMExtras.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useBOMExtras } from './useBOMExtras';
+import { STORAGE_KEYS } from '../utils/storageKeys';
 
 beforeEach(() => {
   localStorage.clear();
@@ -13,7 +14,7 @@ describe('useBOMExtras', () => {
   });
 
   it('loads persisted extras from localStorage on mount', () => {
-    localStorage.setItem('gridfinity-bom-extras', JSON.stringify({ 'bin-1x1::': 2 }));
+    localStorage.setItem(STORAGE_KEYS.BOM_EXTRAS, JSON.stringify({ 'bin-1x1::': 2 }));
     const { result } = renderHook(() => useBOMExtras());
     expect(result.current.extras).toEqual({ 'bin-1x1::': 2 });
   });
@@ -50,18 +51,18 @@ describe('useBOMExtras', () => {
     act(() => { result.current.addExtra('bin-1x1::'); });
     act(() => { result.current.clearExtras(); });
     expect(result.current.extras).toEqual({});
-    expect(localStorage.getItem('gridfinity-bom-extras')).toBeNull();
+    expect(localStorage.getItem(STORAGE_KEYS.BOM_EXTRAS)).toBeNull();
   });
 
   it('persists extras to localStorage on each change', () => {
     const { result } = renderHook(() => useBOMExtras());
     act(() => { result.current.addExtra('bin-2x2::'); });
-    const stored = JSON.parse(localStorage.getItem('gridfinity-bom-extras') ?? '{}');
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEYS.BOM_EXTRAS) ?? '{}');
     expect(stored['bin-2x2::']).toBe(1);
   });
 
   it('handles corrupt localStorage gracefully', () => {
-    localStorage.setItem('gridfinity-bom-extras', 'not-json');
+    localStorage.setItem(STORAGE_KEYS.BOM_EXTRAS, 'not-json');
     const { result } = renderHook(() => useBOMExtras());
     expect(result.current.extras).toEqual({});
   });

--- a/packages/app/src/hooks/useBOMExtras.test.ts
+++ b/packages/app/src/hooks/useBOMExtras.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useBOMExtras } from './useBOMExtras';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('useBOMExtras', () => {
+  it('initializes with empty extras when localStorage is empty', () => {
+    const { result } = renderHook(() => useBOMExtras());
+    expect(result.current.extras).toEqual({});
+  });
+
+  it('loads persisted extras from localStorage on mount', () => {
+    localStorage.setItem('gridfinity-bom-extras', JSON.stringify({ 'bin-1x1::': 2 }));
+    const { result } = renderHook(() => useBOMExtras());
+    expect(result.current.extras).toEqual({ 'bin-1x1::': 2 });
+  });
+
+  it('addExtra adds key with qty 1', () => {
+    const { result } = renderHook(() => useBOMExtras());
+    act(() => { result.current.addExtra('bin-1x1::'); });
+    expect(result.current.extras['bin-1x1::']).toBe(1);
+  });
+
+  it('addExtra is a no-op if key already exists', () => {
+    const { result } = renderHook(() => useBOMExtras());
+    act(() => { result.current.addExtra('bin-1x1::'); });
+    act(() => { result.current.addExtra('bin-1x1::'); });
+    expect(result.current.extras['bin-1x1::']).toBe(1);
+  });
+
+  it('setExtraQty updates the quantity for an existing key', () => {
+    const { result } = renderHook(() => useBOMExtras());
+    act(() => { result.current.addExtra('bin-1x1::'); });
+    act(() => { result.current.setExtraQty('bin-1x1::', 5); });
+    expect(result.current.extras['bin-1x1::']).toBe(5);
+  });
+
+  it('removeExtra deletes the key', () => {
+    const { result } = renderHook(() => useBOMExtras());
+    act(() => { result.current.addExtra('bin-1x1::'); });
+    act(() => { result.current.removeExtra('bin-1x1::'); });
+    expect('bin-1x1::' in result.current.extras).toBe(false);
+  });
+
+  it('clearExtras resets to empty and removes from localStorage', () => {
+    const { result } = renderHook(() => useBOMExtras());
+    act(() => { result.current.addExtra('bin-1x1::'); });
+    act(() => { result.current.clearExtras(); });
+    expect(result.current.extras).toEqual({});
+    expect(localStorage.getItem('gridfinity-bom-extras')).toBeNull();
+  });
+
+  it('persists extras to localStorage on each change', () => {
+    const { result } = renderHook(() => useBOMExtras());
+    act(() => { result.current.addExtra('bin-2x2::'); });
+    const stored = JSON.parse(localStorage.getItem('gridfinity-bom-extras') ?? '{}');
+    expect(stored['bin-2x2::']).toBe(1);
+  });
+
+  it('handles corrupt localStorage gracefully', () => {
+    localStorage.setItem('gridfinity-bom-extras', 'not-json');
+    const { result } = renderHook(() => useBOMExtras());
+    expect(result.current.extras).toEqual({});
+  });
+});

--- a/packages/app/src/hooks/useBOMExtras.ts
+++ b/packages/app/src/hooks/useBOMExtras.ts
@@ -53,8 +53,10 @@ export function useBOMExtras(): UseBOMExtrasReturn {
   }, []);
 
   const clearExtras = useCallback(() => {
-    setExtras({});
-    localStorage.removeItem(STORAGE_KEYS.BOM_EXTRAS);
+    setExtras(() => {
+      localStorage.removeItem(STORAGE_KEYS.BOM_EXTRAS);
+      return {};
+    });
   }, []);
 
   return { extras, addExtra, setExtraQty, removeExtra, clearExtras };

--- a/packages/app/src/hooks/useBOMExtras.ts
+++ b/packages/app/src/hooks/useBOMExtras.ts
@@ -1,0 +1,61 @@
+import { useState, useCallback } from 'react';
+import type { BOMExtras } from '../types/gridfinity';
+import { STORAGE_KEYS } from '../utils/storageKeys';
+
+function loadExtras(): BOMExtras {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEYS.BOM_EXTRAS);
+    return raw ? (JSON.parse(raw) as BOMExtras) : {};
+  } catch {
+    return {};
+  }
+}
+
+function saveExtras(extras: BOMExtras): void {
+  localStorage.setItem(STORAGE_KEYS.BOM_EXTRAS, JSON.stringify(extras));
+}
+
+export interface UseBOMExtrasReturn {
+  extras: BOMExtras;
+  addExtra: (key: string) => void;
+  setExtraQty: (key: string, qty: number) => void;
+  removeExtra: (key: string) => void;
+  clearExtras: () => void;
+}
+
+export function useBOMExtras(): UseBOMExtrasReturn {
+  const [extras, setExtras] = useState<BOMExtras>(loadExtras);
+
+  const addExtra = useCallback((key: string) => {
+    setExtras(prev => {
+      if (key in prev) return prev;
+      const next = { ...prev, [key]: 1 };
+      saveExtras(next);
+      return next;
+    });
+  }, []);
+
+  const setExtraQty = useCallback((key: string, qty: number) => {
+    setExtras(prev => {
+      const next = { ...prev, [key]: qty };
+      saveExtras(next);
+      return next;
+    });
+  }, []);
+
+  const removeExtra = useCallback((key: string) => {
+    setExtras(prev => {
+      const next = { ...prev };
+      delete next[key];
+      saveExtras(next);
+      return next;
+    });
+  }, []);
+
+  const clearExtras = useCallback(() => {
+    setExtras({});
+    localStorage.removeItem(STORAGE_KEYS.BOM_EXTRAS);
+  }, []);
+
+  return { extras, addExtra, setExtraQty, removeExtra, clearExtras };
+}

--- a/packages/app/src/hooks/useBillOfMaterials.test.ts
+++ b/packages/app/src/hooks/useBillOfMaterials.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import { useBillOfMaterials } from './useBillOfMaterials';
 import type { PlacedItem, LibraryItem, BinCustomization } from '../types/gridfinity';
-import { DEFAULT_BIN_CUSTOMIZATION } from '../types/gridfinity';
+import { DEFAULT_BIN_CUSTOMIZATION, getBOMKey } from '../types/gridfinity';
 
 const BASE_ITEM: LibraryItem = {
   id: 'lib1:item1',
@@ -26,6 +26,21 @@ const mockLibraryItems: LibraryItem[] = [
   { id: 'divider-1x1', name: '1x1 Divider', widthUnits: 1, heightUnits: 1, color: '#22c55e', categories: ['divider'] },
   { id: 'organizer-1x3', name: '1x3 Organizer', widthUnits: 1, heightUnits: 3, color: '#f59e0b', categories: ['organizer'] },
 ];
+
+describe('getBOMKey', () => {
+  it('returns itemId:: for undefined customization', () => {
+    expect(getBOMKey('bin-1x1', undefined)).toBe('bin-1x1::');
+  });
+
+  it('returns itemId:: for default customization', () => {
+    expect(getBOMKey('bin-1x1', DEFAULT_BIN_CUSTOMIZATION)).toBe('bin-1x1::');
+  });
+
+  it('returns itemId::serialized for non-default customization', () => {
+    const custom: BinCustomization = { wallPattern: 'grid', lipStyle: 'normal', fingerSlide: 'none', wallCutout: 'none', height: 8 };
+    expect(getBOMKey('bin-1x1', custom)).toBe('bin-1x1::grid|normal|none|none|8');
+  });
+});
 
 describe('useBillOfMaterials', () => {
   it('should return empty array when no items are placed', () => {

--- a/packages/app/src/hooks/useBillOfMaterials.ts
+++ b/packages/app/src/hooks/useBillOfMaterials.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import type { PlacedItem, BOMItem, LibraryItem, BinCustomization } from '../types/gridfinity';
-import { serializeCustomization, isDefaultCustomization } from '../types/gridfinity';
+import { isDefaultCustomization, getBOMKey } from '../types/gridfinity';
 
 export function useBillOfMaterials(placedItems: PlacedItem[], libraryItems: LibraryItem[]): BOMItem[] {
   return useMemo(() => {
@@ -9,10 +9,7 @@ export function useBillOfMaterials(placedItems: PlacedItem[], libraryItems: Libr
 
     placedItems.forEach(placedItem => {
       // Treat undefined and all-default customizations as the same group
-      const customKey = isDefaultCustomization(placedItem.customization)
-        ? ''
-        : serializeCustomization(placedItem.customization);
-      const groupKey = `${placedItem.itemId}::${customKey}`;
+      const groupKey = getBOMKey(placedItem.itemId, placedItem.customization);
       const existing = itemCounts.get(groupKey);
       if (existing) {
         existing.count++;

--- a/packages/app/src/hooks/useLayoutLoader.ts
+++ b/packages/app/src/hooks/useLayoutLoader.ts
@@ -15,11 +15,13 @@ interface UseLayoutLoaderParams {
   loadRefImagePlacements: (placements: RefImagePlacement[]) => void;
   layoutDispatch: React.Dispatch<LayoutMetaAction>;
   getAccessToken: () => string | null;
+  clearExtras?: () => void;
 }
 
 export function useLayoutLoader({
   unitSystem, setWidth, setDepth, setSpacerConfig,
   loadItems, loadRefImagePlacements, layoutDispatch, getAccessToken,
+  clearExtras,
 }: UseLayoutLoaderParams) {
   const handleLoadLayout = useCallback((config: LoadedLayoutConfig) => {
     if (unitSystem === 'imperial') {
@@ -39,6 +41,8 @@ export function useLayoutLoader({
       if (config.ownerEmail) owner += ` <${config.ownerEmail}>`;
     }
 
+    clearExtras?.();
+
     layoutDispatch({
       type: 'LOAD_LAYOUT',
       payload: {
@@ -49,7 +53,7 @@ export function useLayoutLoader({
         owner,
       },
     });
-  }, [unitSystem, setWidth, setDepth, setSpacerConfig, loadItems, loadRefImagePlacements, layoutDispatch]);
+  }, [unitSystem, setWidth, setDepth, setSpacerConfig, loadItems, loadRefImagePlacements, layoutDispatch, clearExtras]);
 
   const loadLayout = useCallback(async (id: number) => {
     const token = getAccessToken();

--- a/packages/app/src/pages/OrderSummaryPage.css
+++ b/packages/app/src/pages/OrderSummaryPage.css
@@ -69,3 +69,171 @@
   color: var(--danger, #dc2626);
   font-size: 0.875rem;
 }
+
+/* ── Collapsible BOM sections ── */
+.bom-section { margin-bottom: var(--space-xl); }
+
+.bom-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-sm) var(--space-md);
+  background: var(--bg-tertiary, #f1f4f7);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
+  cursor: pointer;
+  user-select: none;
+  width: 100%;
+  text-align: left;
+  font-family: inherit;
+}
+.bom-section-header:hover { background: var(--bg-hover, #eef2f6); }
+
+.bom-section-header-left { display: flex; align-items: center; gap: var(--space-sm); }
+
+.bom-section-title {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+}
+
+.bom-section-badge {
+  background: rgba(0, 122, 255, 0.1);
+  color: var(--primary);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  padding: 1px 6px;
+  border-radius: 999px;
+}
+
+.bom-section-chevron {
+  font-size: 0.625rem;
+  color: var(--text-secondary);
+  transition: transform 0.15s;
+}
+.bom-section-chevron--closed { transform: rotate(180deg); }
+
+.bom-section-body {
+  border: 1px solid var(--border-primary);
+  border-top: none;
+  border-radius: 0 0 var(--radius-md) var(--radius-md);
+  overflow: hidden;
+}
+
+/* Extra row qty controls */
+.bom-qty-control { display: flex; align-items: center; gap: 4px; }
+.bom-qty-btn {
+  width: 22px; height: 22px;
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-sm);
+  background: var(--bg-secondary, #fff);
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+  line-height: 1;
+  font-family: inherit;
+}
+.bom-qty-btn:hover { background: var(--bg-hover, #eef2f6); }
+.bom-qty-input {
+  width: 40px;
+  text-align: center;
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-sm);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  padding: 1px 4px;
+  color: var(--text-primary);
+  background: var(--bg-secondary, #fff);
+  font-family: inherit;
+}
+.bom-qty-input:focus { outline: 2px solid var(--primary); outline-offset: -1px; border-color: var(--primary); }
+
+.bom-remove-btn {
+  background: none;
+  border: none;
+  color: var(--text-tertiary, #9ca3af);
+  cursor: pointer;
+  padding: 2px 4px;
+  font-size: 0.875rem;
+  border-radius: 3px;
+  font-family: inherit;
+  line-height: 1;
+}
+.bom-remove-btn:hover { color: var(--danger, #dc2626); background: #FEF2F2; }
+
+/* Add extras row */
+.bom-add-row {
+  padding: var(--space-sm) var(--space-md);
+  background: var(--bg-secondary, #fff);
+  border-top: 1px solid var(--border-secondary);
+  display: flex;
+  gap: var(--space-sm);
+  align-items: center;
+}
+.bom-add-select {
+  flex: 1;
+  padding: 5px 8px;
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-sm);
+  font-size: 0.8125rem;
+  font-family: inherit;
+  color: var(--text-primary);
+  background: var(--bg-secondary, #fff);
+}
+.bom-add-select:focus { outline: 2px solid var(--primary); border-color: var(--primary); }
+.bom-add-btn {
+  padding: 5px 12px;
+  background: var(--primary);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-sm);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  font-family: inherit;
+}
+.bom-add-btn:hover { background: var(--accent-secondary, #0062cc); }
+.bom-add-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+/* Right panel section blocks */
+.order-panel-section { margin-bottom: var(--space-md); }
+.order-panel-section-title {
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  margin: 0 0 var(--space-sm);
+}
+.order-panel-item-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 2px 0;
+  font-size: 0.875rem;
+  gap: var(--space-sm);
+}
+.order-panel-item-left { display: flex; align-items: center; gap: 6px; min-width: 0; }
+.order-panel-item-dot { width: 10px; height: 10px; border-radius: 2px; flex-shrink: 0; }
+.order-panel-item-name { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-weight: 500; }
+.order-panel-item-qty { color: var(--text-secondary); white-space: nowrap; }
+.order-panel-subtotal {
+  display: flex;
+  justify-content: space-between;
+  padding: var(--space-xs) 0;
+  font-size: 0.875rem;
+  font-weight: 600;
+  border-top: 1px solid var(--border-secondary);
+  margin-top: var(--space-xs);
+  color: var(--text-primary);
+}
+.order-panel-divider {
+  border: none;
+  border-top: 1px solid var(--border-primary);
+  margin: var(--space-md) 0;
+}

--- a/packages/app/src/pages/OrderSummaryPage.tsx
+++ b/packages/app/src/pages/OrderSummaryPage.tsx
@@ -77,6 +77,7 @@ export function OrderSummaryPage() {
     setExportPdfError(null);
     await exportOrderSummaryPdf(
       bomItems,
+      extraRows.map(r => ({ ...r.bomItem, quantity: r.qty })),
       { gridResult, spacerConfig, unitSystem, layoutName: layoutMeta.name },
       () => setExportPdfError('PDF export failed. Please try again.'),
     );

--- a/packages/app/src/pages/OrderSummaryPage.tsx
+++ b/packages/app/src/pages/OrderSummaryPage.tsx
@@ -1,13 +1,20 @@
+import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useWorkspace } from '../contexts/WorkspaceContext';
 import { exportOrderSummaryPdf, calculateOrderTotal } from '../utils/exportOrderSummaryPdf';
 import { formatCustomizationDescription } from '../utils/customizationDescription';
+import { getBOMKey } from '../types/gridfinity';
+import type { BOMItem } from '../types/gridfinity';
 import './OrderSummaryPage.css';
 
 export function OrderSummaryPage() {
   const navigate = useNavigate();
   const {
     bomItems,
+    extras,
+    addExtra,
+    setExtraQty,
+    removeExtra,
     gridResult,
     spacerConfig,
     unitSystem,
@@ -22,6 +29,10 @@ export function OrderSummaryPage() {
     setExportPdfError,
   } = useWorkspace();
 
+  const [isConfiguredOpen, setIsConfiguredOpen] = useState(true);
+  const [isExtrasOpen, setIsExtrasOpen] = useState(true);
+  const [addExtraKey, setAddExtraKey] = useState('');
+
   const dimLabel = unitSystem === 'imperial'
     ? `${(drawerWidth / 25.4).toFixed(2)}" × ${(drawerDepth / 25.4).toFixed(2)}"`
     : `${Math.round(drawerWidth)}mm × ${Math.round(drawerDepth)}mm`;
@@ -29,8 +40,38 @@ export function OrderSummaryPage() {
   const totalPlaced = bomItems.reduce((s, i) => s + i.quantity, 0);
   const capacity = gridResult.gridX * gridResult.gridY;
   const pct = capacity > 0 ? Math.min(100, Math.round((totalPlaced / capacity) * 100)) : 0;
-  const { total, hasTbd } = calculateOrderTotal(bomItems, true);
   const hasNoId = !layoutMeta.id;
+
+  // Extras: join extras map with bomItems for display
+  const extraRows = Object.entries(extras)
+    .map(([key, qty]) => ({ key, qty, bomItem: bomItems.find(b => getBOMKey(b.itemId, b.customization) === key) }))
+    .filter((row): row is { key: string; qty: number; bomItem: BOMItem } => row.bomItem !== undefined);
+
+  // Items available to add as extras (not already in extras)
+  const addableItems = bomItems.filter(item => !(getBOMKey(item.itemId, item.customization) in extras));
+
+  // Right panel calculations
+  const { total: configuredTotal, hasTbd: configuredHasTbd } = calculateOrderTotal(bomItems, true);
+  const { total: extrasTotal, hasTbd: extrasHasTbd } = calculateOrderTotal(
+    extraRows.map(r => ({ ...r.bomItem, quantity: r.qty })),
+    true,
+  );
+  const hasTbd = configuredHasTbd || extrasHasTbd;
+  const grandTotal = configuredTotal + extrasTotal;
+  const totalItems = totalPlaced + extraRows.reduce((s, r) => s + r.qty, 0);
+
+  // Full order: configured qty + extras qty per item
+  const fullOrderRows = bomItems.map(item => {
+    const key = getBOMKey(item.itemId, item.customization);
+    const extraQty = extras[key] ?? 0;
+    return { item, totalQty: item.quantity + extraQty };
+  });
+
+  const handleAddExtra = () => {
+    if (!addExtraKey) return;
+    addExtra(addExtraKey);
+    setAddExtraKey('');
+  };
 
   const handleDownloadPdf = async () => {
     setExportPdfError(null);
@@ -82,60 +123,199 @@ export function OrderSummaryPage() {
           </div>
         )}
 
-        {totalPlaced === 0 ? (
-          <div className="order-empty">
-            <p>No items placed yet.</p>
-            <Link to="/">Return to workspace to add items.</Link>
-          </div>
-        ) : (
-          <table className="order-bom-table">
-            <thead>
-              <tr>
-                <th>Component Item</th>
-                <th>Size</th>
-                <th>Qty</th>
-                <th>Unit Price</th>
-                <th>Total</th>
-              </tr>
-            </thead>
-            <tbody>
-              {bomItems.map(item => {
-                const customizationDesc = item.customization
-                  ? formatCustomizationDescription(item.customization)
-                  : '';
-                return (
-                <tr
-                  key={`${item.itemId}-${item.customization ? JSON.stringify(item.customization) : ''}`}
+        {/* ── As Configured section ── */}
+        <div className="bom-section">
+          <button
+            type="button"
+            className="bom-section-header"
+            onClick={() => setIsConfiguredOpen(o => !o)}
+            aria-expanded={isConfiguredOpen}
+          >
+            <div className="bom-section-header-left">
+              <span className="bom-section-title">As Configured</span>
+              <span className="bom-section-badge">{totalPlaced} item{totalPlaced !== 1 ? 's' : ''}</span>
+            </div>
+            <span className={`bom-section-chevron${isConfiguredOpen ? '' : ' bom-section-chevron--closed'}`}>▲</span>
+          </button>
+          {isConfiguredOpen && (
+            <div className="bom-section-body">
+              {totalPlaced === 0 ? (
+                <div className="order-empty">
+                  <p>No items placed yet.</p>
+                  <Link to="/">Return to workspace to add items.</Link>
+                </div>
+              ) : (
+                <table className="order-bom-table">
+                  <thead>
+                    <tr>
+                      <th>Component Item</th>
+                      <th>Size</th>
+                      <th>Qty</th>
+                      <th>Unit Price</th>
+                      <th>Total</th>
+                      <th />
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {bomItems.map(item => {
+                      const customizationDesc = item.customization
+                        ? formatCustomizationDescription(item.customization)
+                        : '';
+                      return (
+                        <tr key={`${item.itemId}-${item.customization ? JSON.stringify(item.customization) : ''}`}>
+                          <td>
+                            <div className="order-bom-item-cell">
+                              <div className="order-bom-color" style={{ backgroundColor: item.color }} />
+                              <div>
+                                <div className="order-bom-name">{item.name}</div>
+                                {customizationDesc && <div className="order-bom-description">{customizationDesc}</div>}
+                              </div>
+                            </div>
+                          </td>
+                          <td className="order-bom-size">{item.widthUnits}&times;{item.heightUnits}</td>
+                          <td>{item.quantity}</td>
+                          <td>
+                            {item.price !== undefined
+                              ? `$${item.price.toFixed(2)}`
+                              : <span className="price-tbd-chip">Price TBD</span>}
+                          </td>
+                          <td>
+                            {item.price !== undefined ? `$${(item.price * item.quantity).toFixed(2)}` : '—'}
+                          </td>
+                          <td />
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* ── Extras section ── */}
+        <div className="bom-section">
+          <button
+            type="button"
+            className="bom-section-header"
+            onClick={() => setIsExtrasOpen(o => !o)}
+            aria-expanded={isExtrasOpen}
+          >
+            <div className="bom-section-header-left">
+              <span className="bom-section-title">Extras</span>
+              {extraRows.length > 0 && (
+                <span className="bom-section-badge">+{extraRows.reduce((s, r) => s + r.qty, 0)}</span>
+              )}
+            </div>
+            <span className={`bom-section-chevron${isExtrasOpen ? '' : ' bom-section-chevron--closed'}`}>▲</span>
+          </button>
+          {isExtrasOpen && (
+            <div className="bom-section-body">
+              {extraRows.length > 0 && (
+                <table className="order-bom-table">
+                  <thead>
+                    <tr>
+                      <th>Component Item</th>
+                      <th>Size</th>
+                      <th>Qty</th>
+                      <th>Unit Price</th>
+                      <th>Total</th>
+                      <th />
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {extraRows.map(({ key, qty, bomItem }) => {
+                      const customizationDesc = bomItem.customization
+                        ? formatCustomizationDescription(bomItem.customization)
+                        : '';
+                      return (
+                        <tr key={key}>
+                          <td>
+                            <div className="order-bom-item-cell">
+                              <div className="order-bom-color" style={{ backgroundColor: bomItem.color }} />
+                              <div>
+                                <div className="order-bom-name">{bomItem.name}</div>
+                                {customizationDesc && <div className="order-bom-description">{customizationDesc}</div>}
+                              </div>
+                            </div>
+                          </td>
+                          <td className="order-bom-size">{bomItem.widthUnits}&times;{bomItem.heightUnits}</td>
+                          <td>
+                            <div className="bom-qty-control">
+                              <button
+                                type="button"
+                                className="bom-qty-btn"
+                                onClick={() => qty > 1 ? setExtraQty(key, qty - 1) : removeExtra(key)}
+                                aria-label="Decrease quantity"
+                              >−</button>
+                              <input
+                                className="bom-qty-input"
+                                type="number"
+                                min={1}
+                                value={qty}
+                                onChange={e => {
+                                  const v = parseInt(e.target.value, 10);
+                                  if (!isNaN(v) && v >= 1) setExtraQty(key, v);
+                                }}
+                                aria-label="Extra quantity"
+                              />
+                              <button
+                                type="button"
+                                className="bom-qty-btn"
+                                onClick={() => setExtraQty(key, qty + 1)}
+                                aria-label="Increase quantity"
+                              >+</button>
+                            </div>
+                          </td>
+                          <td>
+                            {bomItem.price !== undefined
+                              ? `$${bomItem.price.toFixed(2)}`
+                              : <span className="price-tbd-chip">Price TBD</span>}
+                          </td>
+                          <td>
+                            {bomItem.price !== undefined ? `$${(bomItem.price * qty).toFixed(2)}` : '—'}
+                          </td>
+                          <td>
+                            <button
+                              type="button"
+                              className="bom-remove-btn"
+                              onClick={() => removeExtra(key)}
+                              aria-label={`Remove ${bomItem.name} from extras`}
+                            >✕</button>
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              )}
+              <div className="bom-add-row">
+                <select
+                  className="bom-add-select"
+                  value={addExtraKey}
+                  onChange={e => setAddExtraKey(e.target.value)}
+                  aria-label="Select item to add as extra"
                 >
-                  <td>
-                    <div className="order-bom-item-cell">
-                      <div className="order-bom-color" style={{ backgroundColor: item.color }} />
-                      <div>
-                        <div className="order-bom-name">{item.name}</div>
-                        {customizationDesc && <div className="order-bom-description">{customizationDesc}</div>}
-                      </div>
-                    </div>
-                  </td>
-                  <td className="order-bom-size">
-                    {item.widthUnits}&times;{item.heightUnits}
-                  </td>
-                  <td>{item.quantity}</td>
-                  <td>
-                    {item.price !== undefined ? (
-                      `$${item.price.toFixed(2)}`
-                    ) : (
-                      <span className="price-tbd-chip">Price TBD</span>
-                    )}
-                  </td>
-                  <td>
-                    {item.price !== undefined ? `$${(item.price * item.quantity).toFixed(2)}` : '—'}
-                  </td>
-                </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        )}
+                  <option value="">Add an extra item…</option>
+                  {addableItems.map(item => {
+                    const key = getBOMKey(item.itemId, item.customization);
+                    const desc = item.customization ? formatCustomizationDescription(item.customization) : '';
+                    const label = desc ? `${item.name} — ${desc}` : item.name;
+                    return <option key={key} value={key}>{label}</option>;
+                  })}
+                </select>
+                <button
+                  type="button"
+                  className="bom-add-btn"
+                  onClick={handleAddExtra}
+                  disabled={!addExtraKey}
+                >
+                  + Add
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
 
         <div className="order-drawer-info">
           <h3>Drawer Dimensions</h3>
@@ -156,20 +336,75 @@ export function OrderSummaryPage() {
         {exportPdfError && <div role="alert" className="order-export-error">{exportPdfError}</div>}
       </div>
 
+      {/* ── Right panel ── */}
       <aside className="order-summary-panel">
-        <p className="order-panel-title">Order Total</p>
-        <div className="order-total-row">
-          <span>Subtotal</span>
-          <span>${total.toFixed(2)}</span>
+
+        {/* As Configured block */}
+        <div className="order-panel-section">
+          <p className="order-panel-section-title">As Configured</p>
+          {bomItems.map(item => (
+            <div key={getBOMKey(item.itemId, item.customization)} className="order-panel-item-row">
+              <div className="order-panel-item-left">
+                <div className="order-panel-item-dot" style={{ backgroundColor: item.color }} />
+                <span className="order-panel-item-name">{item.name}</span>
+              </div>
+              <span className="order-panel-item-qty">×{item.quantity}</span>
+            </div>
+          ))}
+          <div className="order-panel-subtotal">
+            <span>Subtotal ({totalPlaced})</span>
+            <span>{configuredHasTbd ? 'TBD' : `$${configuredTotal.toFixed(2)}`}</span>
+          </div>
         </div>
+
+        {extraRows.length > 0 && (
+          <>
+            <hr className="order-panel-divider" />
+
+            {/* Extras block */}
+            <div className="order-panel-section">
+              <p className="order-panel-section-title">Extras</p>
+              {extraRows.map(({ key, qty, bomItem }) => (
+                <div key={key} className="order-panel-item-row">
+                  <div className="order-panel-item-left">
+                    <div className="order-panel-item-dot" style={{ backgroundColor: bomItem.color }} />
+                    <span className="order-panel-item-name">{bomItem.name}</span>
+                  </div>
+                  <span className="order-panel-item-qty">×{qty}</span>
+                </div>
+              ))}
+              <div className="order-panel-subtotal">
+                <span>Subtotal ({extraRows.reduce((s, r) => s + r.qty, 0)})</span>
+                <span>{extrasHasTbd ? 'TBD' : `$${extrasTotal.toFixed(2)}`}</span>
+              </div>
+            </div>
+
+            <hr className="order-panel-divider" />
+
+            {/* Full Order block */}
+            <div className="order-panel-section">
+              <p className="order-panel-section-title">Full Order</p>
+              {fullOrderRows.map(({ item, totalQty }) => (
+                <div key={getBOMKey(item.itemId, item.customization)} className="order-panel-item-row">
+                  <div className="order-panel-item-left">
+                    <div className="order-panel-item-dot" style={{ backgroundColor: item.color }} />
+                    <span className="order-panel-item-name">{item.name}</span>
+                  </div>
+                  <span className="order-panel-item-qty">×{totalQty}</span>
+                </div>
+              ))}
+            </div>
+          </>
+        )}
+
         {hasTbd && (
           <div className="order-tbd-note">
             &dagger; One or more items are Price TBD. A confirmed quote will follow before any build or shipment.
           </div>
         )}
         <div className="order-total-row grand">
-          <span>Total</span>
-          <span>{hasTbd ? 'Pending quote' : `$${total.toFixed(2)}`}</span>
+          <span>Total ({totalItems})</span>
+          <span>{hasTbd ? 'Pending quote' : `$${grandTotal.toFixed(2)}`}</span>
         </div>
 
         <div className="order-panel-actions">

--- a/packages/app/src/pages/OrderSummaryPage.tsx
+++ b/packages/app/src/pages/OrderSummaryPage.tsx
@@ -130,6 +130,7 @@ export function OrderSummaryPage() {
             className="bom-section-header"
             onClick={() => setIsConfiguredOpen(o => !o)}
             aria-expanded={isConfiguredOpen}
+            aria-label="Toggle As Configured section"
           >
             <div className="bom-section-header-left">
               <span className="bom-section-title">As Configured</span>
@@ -200,6 +201,7 @@ export function OrderSummaryPage() {
             className="bom-section-header"
             onClick={() => setIsExtrasOpen(o => !o)}
             aria-expanded={isExtrasOpen}
+            aria-label="Toggle Extras section"
           >
             <div className="bom-section-header-left">
               <span className="bom-section-title">Extras</span>

--- a/packages/app/src/types/gridfinity.ts
+++ b/packages/app/src/types/gridfinity.ts
@@ -145,6 +145,14 @@ export function isDefaultCustomization(c: BinCustomization | undefined): boolean
     && c.height === 8;
 }
 
+export function getBOMKey(itemId: string, customization?: BinCustomization): string {
+  const customKey = isDefaultCustomization(customization) ? '' : serializeCustomization(customization);
+  return `${itemId}::${customKey}`;
+}
+
+// Maps BOM group key (itemId::serializedCustomization) → extra quantity
+export type BOMExtras = Record<string, number>;
+
 export interface LibraryMeta {
   customizableFields: CustomizableField[];
   customizationDefaults: Partial<BinCustomization>;

--- a/packages/app/src/utils/exportOrderSummaryPdf.test.ts
+++ b/packages/app/src/utils/exportOrderSummaryPdf.test.ts
@@ -39,3 +39,20 @@ describe('calculateOrderTotal', () => {
     expect(hasTbd).toBe(true);
   });
 });
+
+describe('exportOrderSummaryPdf with extras', () => {
+  it('formatOrderSummaryRows formats extra items identically to configured rows', () => {
+    const extras: BOMItem[] = [{ ...item1, quantity: 2 }];
+    const rows = formatOrderSummaryRows(extras);
+    expect(rows[0]).toEqual(['Small Bin', '1\u00d71', '2', '$10.00', '$20.00']);
+  });
+
+  it('calculateOrderTotal sums extras separately from configured', () => {
+    const extras: BOMItem[] = [{ ...item1, quantity: 1 }]; // 1 × $10
+    const configuredResult = calculateOrderTotal([item1], true); // 3 × $10 = $30
+    const extrasResult = calculateOrderTotal(extras, true);      // 1 × $10 = $10
+    expect(configuredResult.total).toBe(30);
+    expect(extrasResult.total).toBe(10);
+    expect(configuredResult.total + extrasResult.total).toBe(40);
+  });
+});

--- a/packages/app/src/utils/exportOrderSummaryPdf.test.ts
+++ b/packages/app/src/utils/exportOrderSummaryPdf.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { formatOrderSummaryRows, calculateOrderTotal } from './exportOrderSummaryPdf';
 import type { BOMItem } from '../types/gridfinity';
 
@@ -40,19 +40,67 @@ describe('calculateOrderTotal', () => {
   });
 });
 
-describe('exportOrderSummaryPdf with extras', () => {
-  it('formatOrderSummaryRows formats extra items identically to configured rows', () => {
-    const extras: BOMItem[] = [{ ...item1, quantity: 2 }];
-    const rows = formatOrderSummaryRows(extras);
-    expect(rows[0]).toEqual(['Small Bin', '1\u00d71', '2', '$10.00', '$20.00']);
+const { mockAutoTable, mockSave, mockText, mockSetFont, mockSetFontSize, mockSetTextColor } = vi.hoisted(() => ({
+  mockAutoTable: vi.fn(),
+  mockSave: vi.fn(),
+  mockText: vi.fn(),
+  mockSetFont: vi.fn(),
+  mockSetFontSize: vi.fn(),
+  mockSetTextColor: vi.fn(),
+}));
+
+vi.mock('jspdf', () => ({
+  default: vi.fn(function () {
+    return {
+      internal: { pageSize: { getWidth: () => 210 } },
+      setFontSize: mockSetFontSize,
+      setFont: mockSetFont,
+      text: mockText,
+      setTextColor: mockSetTextColor,
+      save: mockSave,
+      lastAutoTable: { finalY: 100 },
+    };
+  }),
+}));
+
+vi.mock('jspdf-autotable', () => ({ default: mockAutoTable }));
+
+vi.mock('./exportPdf', () => ({
+  getOrientation: () => 'portrait',
+  generateFilename: () => 'order-summary.pdf',
+}));
+
+describe('exportOrderSummaryPdf', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
   });
 
-  it('calculateOrderTotal sums extras separately from configured', () => {
-    const extras: BOMItem[] = [{ ...item1, quantity: 1 }]; // 1 × $10
-    const configuredResult = calculateOrderTotal([item1], true); // 3 × $10 = $30
-    const extrasResult = calculateOrderTotal(extras, true);      // 1 × $10 = $10
-    expect(configuredResult.total).toBe(30);
-    expect(extrasResult.total).toBe(10);
-    expect(configuredResult.total + extrasResult.total).toBe(40);
+  it('calls autoTable once when extraItems is empty', async () => {
+    const { exportOrderSummaryPdf } = await import('./exportOrderSummaryPdf');
+    await exportOrderSummaryPdf(
+      [item1],
+      [],
+      {
+        gridResult: { gridX: 4, gridY: 4, actualWidth: 168, actualDepth: 168, gapWidth: 0, gapDepth: 0 },
+        spacerConfig: { horizontal: 'none', vertical: 'none' },
+        unitSystem: 'metric',
+      },
+    );
+    expect(mockAutoTable).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls autoTable twice when extraItems is non-empty', async () => {
+    const { exportOrderSummaryPdf } = await import('./exportOrderSummaryPdf');
+    const extras: BOMItem[] = [{ ...item1, quantity: 1 }];
+    await exportOrderSummaryPdf(
+      [item1],
+      extras,
+      {
+        gridResult: { gridX: 4, gridY: 4, actualWidth: 168, actualDepth: 168, gapWidth: 0, gapDepth: 0 },
+        spacerConfig: { horizontal: 'none', vertical: 'none' },
+        unitSystem: 'metric',
+      },
+    );
+    expect(mockAutoTable).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/app/src/utils/exportOrderSummaryPdf.ts
+++ b/packages/app/src/utils/exportOrderSummaryPdf.ts
@@ -35,6 +35,7 @@ export interface ExportOrderSummaryConfig {
 
 export async function exportOrderSummaryPdf(
   bomItems: BOMItem[],
+  extraItems: BOMItem[],
   config: ExportOrderSummaryConfig,
   onError?: (err: unknown) => void,
 ): Promise<void> {
@@ -82,8 +83,14 @@ export async function exportOrderSummaryPdf(
     pdf.text(`Spacers: H ${spacerConfig.horizontal}, V ${spacerConfig.vertical}`, margin, cursorY + 5);
     cursorY += 13;
 
-    const { total, hasTbd } = calculateOrderTotal(bomItems, true);
-    const totalQty = bomItems.reduce((sum, i) => sum + i.quantity, 0);
+    const { total: configuredTotal, hasTbd: configuredHasTbd } = calculateOrderTotal(bomItems, true);
+    const configuredQty = bomItems.reduce((sum, i) => sum + i.quantity, 0);
+
+    // As Configured table
+    pdf.setFontSize(11);
+    pdf.setFont('helvetica', 'bold');
+    pdf.text('As Configured', margin, cursorY);
+    cursorY += 5;
 
     autoTable(pdf, {
       startY: cursorY,
@@ -91,17 +98,10 @@ export async function exportOrderSummaryPdf(
       body: [
         ...formatOrderSummaryRows(bomItems),
         [
-          {
-            content: `${totalQty} item${totalQty !== 1 ? 's' : ''}`,
-            colSpan: 2,
-            styles: { fontStyle: 'bold' },
-          },
+          { content: `${configuredQty} item${configuredQty !== 1 ? 's' : ''}`, colSpan: 2, styles: { fontStyle: 'bold' } },
           '',
           '',
-          {
-            content: hasTbd ? 'Pending quote' : `$${total.toFixed(2)}`,
-            styles: { fontStyle: 'bold' },
-          },
+          { content: configuredHasTbd ? 'Pending quote' : `$${configuredTotal.toFixed(2)}`, styles: { fontStyle: 'bold' } },
         ],
       ],
       margin: { left: margin, right: margin },
@@ -109,9 +109,54 @@ export async function exportOrderSummaryPdf(
       headStyles: { fillColor: [0, 122, 255] },
     });
 
-    if (hasTbd) {
+    if (extraItems.length > 0) {
       const pdfWithTable = pdf as { lastAutoTable?: { finalY: number } };
-      const finalY = pdfWithTable.lastAutoTable?.finalY ?? cursorY;
+      cursorY = (pdfWithTable.lastAutoTable?.finalY ?? cursorY) + 8;
+
+      const { total: extrasTotal, hasTbd: extrasHasTbd } = calculateOrderTotal(extraItems, true);
+      const extrasQty = extraItems.reduce((sum, i) => sum + i.quantity, 0);
+      const grandTotal = configuredTotal + extrasTotal;
+      const grandQty = configuredQty + extrasQty;
+      const grandHasTbd = configuredHasTbd || extrasHasTbd;
+
+      pdf.setFontSize(11);
+      pdf.setFont('helvetica', 'bold');
+      pdf.text('Extras', margin, cursorY);
+      cursorY += 5;
+
+      autoTable(pdf, {
+        startY: cursorY,
+        head: [['Component', 'Size', 'Qty', 'Unit Price', 'Total']],
+        body: [
+          ...formatOrderSummaryRows(extraItems),
+          [
+            { content: `${extrasQty} item${extrasQty !== 1 ? 's' : ''}`, colSpan: 2, styles: { fontStyle: 'bold' } },
+            '',
+            '',
+            { content: extrasHasTbd ? 'Pending quote' : `$${extrasTotal.toFixed(2)}`, styles: { fontStyle: 'bold' } },
+          ],
+        ],
+        margin: { left: margin, right: margin },
+        styles: { fontSize: 9 },
+        headStyles: { fillColor: [80, 80, 80] },
+      });
+
+      const pdfWithExtras = pdf as { lastAutoTable?: { finalY: number } };
+      cursorY = (pdfWithExtras.lastAutoTable?.finalY ?? cursorY) + 4;
+
+      pdf.setFontSize(10);
+      pdf.setFont('helvetica', 'bold');
+      pdf.text(
+        `Full Order Total: ${grandQty} items — ${grandHasTbd ? 'Pending quote' : `$${grandTotal.toFixed(2)}`}`,
+        margin,
+        cursorY,
+      );
+    }
+
+    const anyHasTbd = configuredHasTbd || extraItems.some(i => i.price === undefined);
+    if (anyHasTbd) {
+      const pdfFinal = pdf as { lastAutoTable?: { finalY: number } };
+      const finalY = pdfFinal.lastAutoTable?.finalY ?? cursorY;
       pdf.setFontSize(8);
       pdf.setTextColor(180, 83, 9);
       pdf.text(

--- a/packages/app/src/utils/exportOrderSummaryPdf.ts
+++ b/packages/app/src/utils/exportOrderSummaryPdf.ts
@@ -45,6 +45,7 @@ export async function exportOrderSummaryPdf(
     const filename = generateFilename(layoutName);
 
     const pdf = new jsPDF({ orientation, unit: 'mm', format: 'a4' });
+    const pdfTyped = pdf as jsPDF & { lastAutoTable?: { finalY: number } };
     const pageWidth = pdf.internal.pageSize.getWidth();
     const margin = 15;
     let cursorY = margin;
@@ -86,6 +87,14 @@ export async function exportOrderSummaryPdf(
     const { total: configuredTotal, hasTbd: configuredHasTbd } = calculateOrderTotal(bomItems, true);
     const configuredQty = bomItems.reduce((sum, i) => sum + i.quantity, 0);
 
+    const { total: extrasTotal, hasTbd: extrasHasTbd } = extraItems.length > 0
+      ? calculateOrderTotal(extraItems, true)
+      : { total: 0, hasTbd: false };
+    const extrasQty = extraItems.reduce((sum, i) => sum + i.quantity, 0);
+    const grandTotal = configuredTotal + extrasTotal;
+    const grandQty = configuredQty + extrasQty;
+    const grandHasTbd = configuredHasTbd || extrasHasTbd;
+
     // As Configured table
     pdf.setFontSize(11);
     pdf.setFont('helvetica', 'bold');
@@ -110,14 +119,7 @@ export async function exportOrderSummaryPdf(
     });
 
     if (extraItems.length > 0) {
-      const pdfWithTable = pdf as { lastAutoTable?: { finalY: number } };
-      cursorY = (pdfWithTable.lastAutoTable?.finalY ?? cursorY) + 8;
-
-      const { total: extrasTotal, hasTbd: extrasHasTbd } = calculateOrderTotal(extraItems, true);
-      const extrasQty = extraItems.reduce((sum, i) => sum + i.quantity, 0);
-      const grandTotal = configuredTotal + extrasTotal;
-      const grandQty = configuredQty + extrasQty;
-      const grandHasTbd = configuredHasTbd || extrasHasTbd;
+      cursorY = (pdfTyped.lastAutoTable?.finalY ?? cursorY) + 8;
 
       pdf.setFontSize(11);
       pdf.setFont('helvetica', 'bold');
@@ -141,8 +143,7 @@ export async function exportOrderSummaryPdf(
         headStyles: { fillColor: [80, 80, 80] },
       });
 
-      const pdfWithExtras = pdf as { lastAutoTable?: { finalY: number } };
-      cursorY = (pdfWithExtras.lastAutoTable?.finalY ?? cursorY) + 4;
+      cursorY = (pdfTyped.lastAutoTable?.finalY ?? cursorY) + 4;
 
       pdf.setFontSize(10);
       pdf.setFont('helvetica', 'bold');
@@ -151,18 +152,16 @@ export async function exportOrderSummaryPdf(
         margin,
         cursorY,
       );
+      cursorY += 6;
     }
 
-    const anyHasTbd = configuredHasTbd || extraItems.some(i => i.price === undefined);
-    if (anyHasTbd) {
-      const pdfFinal = pdf as { lastAutoTable?: { finalY: number } };
-      const finalY = pdfFinal.lastAutoTable?.finalY ?? cursorY;
+    if (grandHasTbd) {
       pdf.setFontSize(8);
       pdf.setTextColor(180, 83, 9);
       pdf.text(
         '\u2020 Items marked "Price TBD" will receive a confirmed quote before any build or shipment.',
         margin,
-        finalY + 6,
+        cursorY + 6,
       );
       pdf.setTextColor(0, 0, 0);
     }

--- a/packages/app/src/utils/exportOrderSummaryPdf.ts
+++ b/packages/app/src/utils/exportOrderSummaryPdf.ts
@@ -118,8 +118,10 @@ export async function exportOrderSummaryPdf(
       headStyles: { fillColor: [0, 122, 255] },
     });
 
+    cursorY = pdfTyped.lastAutoTable?.finalY ?? cursorY;
+
     if (extraItems.length > 0) {
-      cursorY = (pdfTyped.lastAutoTable?.finalY ?? cursorY) + 8;
+      cursorY = cursorY + 8;
 
       pdf.setFontSize(11);
       pdf.setFont('helvetica', 'bold');
@@ -152,7 +154,6 @@ export async function exportOrderSummaryPdf(
         margin,
         cursorY,
       );
-      cursorY += 6;
     }
 
     if (grandHasTbd) {

--- a/packages/app/src/utils/storageKeys.ts
+++ b/packages/app/src/utils/storageKeys.ts
@@ -10,6 +10,7 @@ export const STORAGE_KEYS = {
   CUSTOM_LIBRARY: 'gridfinity-custom-library',
   CUSTOM_CATEGORIES: 'gridfinity-custom-categories',
   WALKTHROUGH_SEEN: 'gridfinity-walkthrough-seen',
+  BOM_EXTRAS: 'gridfinity-bom-extras',
 } as const;
 
 export type StorageKey = typeof STORAGE_KEYS[keyof typeof STORAGE_KEYS];


### PR DESCRIPTION
## Summary

- Adds a `useBOMExtras` hook that persists manually added extra item quantities in localStorage (keyed by `itemId::customization`)
- Redesigns the Order Summary page with two collapsible sections ("As Configured" from the grid, "Extras" for manually added quantities) and a right panel showing three blocks: As Configured subtotal, Extras subtotal, and Full Order grand total
- Updates the PDF export to include an "Extras" table and "Full Order Total" line when extras are present

## Test Plan

- [ ] Place items on the grid and navigate to Order Summary — verify "As Configured" section shows grid-derived BOM
- [ ] Add extras via the dropdown; verify qty controls (±, direct input), remove button, and right panel update
- [ ] Refresh the page — extras should persist in localStorage
- [ ] Load a different layout — extras should be cleared
- [ ] Download PDF with extras — verify "As Configured", "Extras", and "Full Order Total" sections appear
- [ ] Download PDF without extras — verify original single-table layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)