### PR TITLE
security: harden server and infra against public exposure

### DIFF
--- a/docs/superpowers/plans/2026-04-13-mobile-layout-design.md
+++ b/docs/superpowers/plans/2026-04-13-mobile-layout-design.md
@@ -1,0 +1,102 @@
+# Mobile Layout Design
+
+## Goal
+
+Make the gridfinity customizer usable on tablets (768px–1024px) and phones (≤768px) by switching to a collapsible-sidebar layout that keeps the grid canvas always visible.
+
+## Problem
+
+On tablet viewports the three-column layout (library | grid | settings) collapses in a way that hides the grid canvas. The component library appears on the left and grid settings on the right, leaving no room for the actual grid.
+
+## Target Devices
+
+- **Tablet breakpoint:** ≤1024px (iPad, Android tablets)
+- **Phone breakpoint:** ≤768px (iPhone, small Android)
+
+---
+
+## Layout Architecture
+
+At `≤1024px` the app switches from the desktop 3-column flex layout to an **overlay panel** model:
+
+- `.app-main` fills 100% of the available space with `position: relative`
+- The grid canvas always occupies the full viewport
+- The library panel (left) and settings panel (right) become **floating overlays** that sit on top of the canvas when open, or collapse to a **44px icon strip** pinned to their respective edges when closed
+- No layout shift when panels open/close — the grid never moves
+
+At `≤768px` icon strips shrink to 36px and expanded overlay panels go full-width.
+
+### Collapse State
+
+A new `useMobileLayout` hook tracks two booleans: `libraryOpen` and `settingsOpen`. State persists to `localStorage` so the preference survives page refresh.
+
+Toggle buttons sit at the top of each icon strip:
+- `☰` for library (left edge)
+- `⚙` for settings (right edge)
+- `✕` closes an open panel
+
+No mutual exclusion — both panels can be open simultaneously.
+
+---
+
+## Library Panel (left)
+
+**Collapsed (icon strip):**
+- 44px wide strip pinned to left edge
+- `☰` toggle button at top
+- Category icons stacked vertically; clicking one opens the panel scrolled to that category
+
+**Expanded (overlay):**
+- 260px wide overlay slides in from left
+- Resize handle disabled on tablet (fixed width)
+- Semi-transparent backdrop covers only the grid area; tapping it closes the panel
+- Library item grid: `repeat(auto-fill, 80px)` cards on tablet (down from 120px desktop)
+- At ≤768px: full-width panel, 72px cards
+
+---
+
+## Settings Panel (right)
+
+**Collapsed (icon strip):**
+- 44px wide strip pinned to right edge
+- `⚙` toggle button at top
+
+**Expanded (overlay):**
+- 280px wide overlay slides in from right
+- Settings content unchanged — existing collapsible sections work as-is
+
+---
+
+## Mobile E2E Tests
+
+New spec: `packages/app/e2e/tests/mobile-layout.spec.ts`  
+New page object: `packages/app/e2e/pages/MobileLayoutPage.ts`
+
+Viewports tested:
+- `768×1024` (iPad)
+- `390×844` (iPhone)
+
+Test cases:
+- Library panel is collapsed by default on tablet
+- Tapping library toggle opens the panel
+- Tapping backdrop closes the library panel
+- Settings panel is collapsed by default on tablet
+- Tapping settings toggle opens the panel
+- Drag-and-drop from library to grid works with both panels collapsed
+- Library card size is ≤80px on tablet viewport
+- Panel collapse state persists after page refresh
+- Both panels can be open simultaneously
+
+**Existing test audit:** scan current E2E specs for desktop-only assumptions (hardcoded viewport sizes, pixel-offset drags, desktop-only selectors) that would fail at tablet width.
+
+---
+
+## Files to Create / Modify
+
+| File | Action |
+|------|--------|
+| `packages/app/src/hooks/useMobileLayout.ts` | Create — `libraryOpen`/`settingsOpen` state + localStorage |
+| `packages/app/src/pages/WorkspacePage.tsx` | Modify — wire `useMobileLayout`, render toggle buttons and backdrops |
+| `packages/app/src/App.css` | Modify — overlay positioning, icon strip styles, card size reduction, media queries |
+| `packages/app/e2e/tests/mobile-layout.spec.ts` | Create — mobile-exclusive test spec |
+| `packages/app/e2e/pages/MobileLayoutPage.ts` | Create — page object for mobile tests |

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -19,10 +19,10 @@ services:
     expose:
       - "3001"
     environment:
-      - NODE_ENV=test
+      - NODE_ENV=production
       - PORT=3001
-      - JWT_SECRET=${JWT_SECRET:-dev-jwt-secret-change-in-production}
-      - JWT_REFRESH_SECRET=${JWT_REFRESH_SECRET:-dev-refresh-secret-change-in-production}
+      - JWT_SECRET=${JWT_SECRET}
+      - JWT_REFRESH_SECRET=${JWT_REFRESH_SECRET}
       - CORS_ORIGIN=http://localhost:32888
       - DB_PATH=/data/gridfinity.db
       - IMAGE_DIR=/data/images

--- a/infra/nginx.compose.conf
+++ b/infra/nginx.compose.conf
@@ -5,6 +5,13 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Security headers
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none';" always;
+
     # Cached proxy for API image assets (before generic /api/ block)
     location /api/v1/images/ {
         proxy_pass http://backend:3001;

--- a/packages/app/src/api/bom.api.ts
+++ b/packages/app/src/api/bom.api.ts
@@ -59,8 +59,10 @@ export async function submitBom(
   return result.data;
 }
 
-export async function downloadBom(id: number): Promise<string> {
-  const response = await fetch(`${API_BASE_URL}/bom/${id}/download`);
+export async function downloadBom(id: number, accessToken?: string): Promise<string> {
+  const headers: Record<string, string> = {};
+  if (accessToken) headers.Authorization = `Bearer ${accessToken}`;
+  const response = await fetch(`${API_BASE_URL}/bom/${id}/download`, { headers });
   if (!response.ok) {
     throw new Error(`Download failed with status ${response.status}`);
   }

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -1,5 +1,10 @@
 import { z } from 'zod';
 
+const KNOWN_WEAK_SECRETS = new Set([
+  'dev-jwt-secret-change-in-production',
+  'dev-refresh-secret-change-in-production',
+]);
+
 const envSchema = z.object({
   PORT: z.coerce.number().default(3001),
   NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
@@ -7,12 +12,29 @@ const envSchema = z.object({
   IMAGE_DIR: z.string().default('./data/images'),
   LOG_LEVEL: z.enum(['fatal', 'error', 'warn', 'info', 'debug', 'trace']).default('info'),
   CORS_ORIGIN: z.string().default('http://localhost:5173'),
-  JWT_SECRET: z.string().default('dev-jwt-secret-change-in-production'),
-  JWT_REFRESH_SECRET: z.string().default('dev-refresh-secret-change-in-production'),
+  JWT_SECRET: z.string().min(1, 'JWT_SECRET must be set').default('dev-jwt-secret-change-in-production'),
+  JWT_REFRESH_SECRET: z.string().min(1, 'JWT_REFRESH_SECRET must be set').default('dev-refresh-secret-change-in-production'),
   USER_STL_DIR: z.string().default('./data/user-stls'),
   USER_STL_IMAGE_DIR: z.string().default('./data/user-stl-images'),
   MAX_STL_WORKERS: z.coerce.number().default(2),
   PYTHON_SCRIPT_DIR: z.string().default('./scripts/py'),
+}).superRefine((data, ctx) => {
+  if (data.NODE_ENV === 'production') {
+    if (KNOWN_WEAK_SECRETS.has(data.JWT_SECRET)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['JWT_SECRET'],
+        message: 'JWT_SECRET must be changed from the default value in production. Set a strong random secret (e.g. openssl rand -hex 32).',
+      });
+    }
+    if (KNOWN_WEAK_SECRETS.has(data.JWT_REFRESH_SECRET)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['JWT_REFRESH_SECRET'],
+        message: 'JWT_REFRESH_SECRET must be changed from the default value in production. Set a strong random secret (e.g. openssl rand -hex 32).',
+      });
+    }
+  }
 });
 
 export type Config = z.infer<typeof envSchema>;

--- a/packages/server/src/controllers/userStls.controller.ts
+++ b/packages/server/src/controllers/userStls.controller.ts
@@ -196,7 +196,9 @@ export async function downloadFileHandler(req: Request, res: Response, next: Nex
     if (!row) return res.status(404).json({ error: 'Not found' });
     if (!checkOwnership(row, req, res)) return;
 
-    res.setHeader('Content-Disposition', `attachment; filename="${row.originalFilename}"`);
+    // Sanitize filename: allow only safe ASCII word chars, dots, hyphens, spaces
+    const safeFilename = row.originalFilename.replace(/[^\w.\- ]/g, '_');
+    res.setHeader('Content-Disposition', `attachment; filename="${safeFilename}"`);
     return res.sendFile(row.filePath);
   } catch (err) {
     next(err);

--- a/packages/server/src/db/seed.ts
+++ b/packages/server/src/db/seed.ts
@@ -31,10 +31,15 @@ async function seed(): Promise<void> {
   // Reseed library data from JSON files
   await reseedLibraryData(client, logger);
 
-  // Full reset: wipe and reseed users
-  await client.execute('DELETE FROM refresh_tokens;');
-  await client.execute('DELETE FROM users;');
-  await seedDefaultUsers(client, logger);
+  // Seed default users only if the table is empty (first-run only).
+  // Never wipe existing users in production to prevent accidental data loss.
+  const existingUsers = await client.execute('SELECT COUNT(*) as count FROM users;');
+  const userCount = Number((existingUsers.rows[0] as { count: number }).count);
+  if (userCount === 0) {
+    await seedDefaultUsers(client, logger);
+  } else {
+    logger.info(`Skipping user seed — ${userCount} user(s) already exist.`);
+  }
 
   logger.info('Seed complete!');
   client.close();

--- a/packages/server/src/db/seedUsers.ts
+++ b/packages/server/src/db/seedUsers.ts
@@ -1,14 +1,34 @@
+import { randomBytes } from 'node:crypto';
 import type { Client } from '@libsql/client';
 import type { Logger } from 'pino';
 
 /**
  * Seeds default user accounts (admin + test).
  * Does NOT delete existing users — caller decides whether to wipe first.
+ *
+ * Admin password is read from ADMIN_INITIAL_PASSWORD env var.
+ * If not set and NODE_ENV=production, a random password is generated and logged once.
+ * If not set in dev/test, falls back to 'admin' for convenience.
  */
 export async function seedDefaultUsers(client: Client, logger: Logger): Promise<void> {
   const argon2 = await import('argon2');
 
-  const adminPasswordHash = await argon2.default.hash('admin', { type: argon2.default.argon2id });
+  const isProduction = process.env.NODE_ENV === 'production';
+  let adminPassword = process.env.ADMIN_INITIAL_PASSWORD ?? '';
+
+  if (!adminPassword) {
+    if (isProduction) {
+      adminPassword = randomBytes(16).toString('hex');
+      logger.warn(
+        { adminPassword },
+        'ADMIN_INITIAL_PASSWORD not set — generated random admin password. Save this now, it will not be shown again.',
+      );
+    } else {
+      adminPassword = 'admin';
+    }
+  }
+
+  const adminPasswordHash = await argon2.default.hash(adminPassword, { type: argon2.default.argon2id });
   const testPasswordHash = await argon2.default.hash('test123', { type: argon2.default.argon2id });
 
   await client.execute({
@@ -24,5 +44,4 @@ export async function seedDefaultUsers(client: Client, logger: Logger): Promise<
   });
 
   logger.info('Created default accounts: admin@gridfinity.local, test@gridfinity.local');
-  logger.warn('Change default passwords before deploying to production!');
 }

--- a/packages/server/src/routes/bom.routes.ts
+++ b/packages/server/src/routes/bom.routes.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { optionalAuth } from '../middleware/auth.js';
+import { optionalAuth, requireAuth } from '../middleware/auth.js';
 import * as bomController from '../controllers/bom.controller.js';
 
 const router = Router();
@@ -7,7 +7,7 @@ const router = Router();
 // Optional auth - authenticated users get their userId linked
 router.post('/submit', optionalAuth, bomController.submitBom);
 
-// Public - download BOM JSON
-router.get('/:id/download', bomController.downloadBom);
+// Auth required - prevents enumeration of other users' BOM data
+router.get('/:id/download', requireAuth, bomController.downloadBom);
 
 export default router;

--- a/packages/server/tests/bom.test.ts
+++ b/packages/server/tests/bom.test.ts
@@ -199,7 +199,8 @@ describe('BOM endpoints', () => {
 
     it('downloads BOM JSON by ID', async () => {
       const res = await request(app)
-        .get(`/api/v1/bom/${bomId}/download`);
+        .get(`/api/v1/bom/${bomId}/download`)
+        .set('Authorization', `Bearer ${accessToken}`);
 
       expect(res.status).toBe(200);
       expect(res.headers['content-type']).toContain('application/json');
@@ -212,14 +213,16 @@ describe('BOM endpoints', () => {
 
     it('returns 404 for non-existent BOM', async () => {
       const res = await request(app)
-        .get('/api/v1/bom/99999/download');
+        .get('/api/v1/bom/99999/download')
+        .set('Authorization', `Bearer ${accessToken}`);
 
       expect(res.status).toBe(404);
     });
 
     it('returns 400 for invalid ID', async () => {
       const res = await request(app)
-        .get('/api/v1/bom/abc/download');
+        .get('/api/v1/bom/abc/download')
+        .set('Authorization', `Bearer ${accessToken}`);
 
       expect(res.status).toBe(400);
     });


### PR DESCRIPTION
## Summary

- **S-1**: Set `NODE_ENV=production` in Docker Compose so all production guards activate
- **S-2**: Require `JWT_SECRET`/`JWT_REFRESH_SECRET` env vars with no insecure fallback; reject known weak defaults at startup via `config.ts` superRefine check
- **S-3**: Admin password read from `ADMIN_INITIAL_PASSWORD` env var; auto-generates a random password in production if unset (logged once); seed skips if users already exist to prevent accidental wipe
- **S-4**: BOM download endpoint (`GET /bom/:id/download`) now requires auth to prevent sequential ID enumeration; `bom.api.ts` forwards access token; `bom.test.ts` updated
- **S-5**: `Content-Disposition` filename sanitized in STL download controller to prevent header injection
- **S-6**: nginx security headers added: `Content-Security-Policy`, `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, `Permissions-Policy`

## Before deploying

You must set these environment variables before running `docker compose up`:
```bash
export JWT_SECRET=$(openssl rand -hex 32)
export JWT_REFRESH_SECRET=$(openssl rand -hex 32)
# Optionally:
export ADMIN_INITIAL_PASSWORD=<your-chosen-password>
```

## Test plan

- [x] `npm run lint` — clean
- [x] `npx vitest run packages/server` — 236 tests pass (including updated bom.test.ts)
- [x] `npx vitest run packages/app` — 1188 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)