### PR TITLE
feat: library parameter options + code quality improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ tools/gridfinity-generator/__pycache__/
 # Git worktrees
 .worktrees/
 .superpowers/
+.worktrees/

--- a/packages/app/public/libraries/bins_labeled/index.json
+++ b/packages/app/public/libraries/bins_labeled/index.json
@@ -2,10 +2,10 @@
   "version": "1.0.0",
   "baseModel": "gridfinity_basic_cup.scad",
   "customizableFields": [
-    "lipStyle",
-    "wallPattern",
-    "fingerSlide",
-    "wallCutout"
+    { "field": "wallPattern", "label": "Wall Pattern", "options": ["none", "grid", "hexgrid", "brick"] },
+    { "field": "lipStyle",    "label": "Lip Style",    "options": ["normal", "reduced", "minimum", "none"] },
+    { "field": "fingerSlide", "label": "Finger Slide", "options": ["none", "rounded", "chamfered"] },
+    { "field": "wallCutout",  "label": "Wall Cutout",  "options": ["none", "vertical", "horizontal", "both"] }
   ],
   "items": [
     {

--- a/packages/app/public/libraries/bins_labeled/index.json
+++ b/packages/app/public/libraries/bins_labeled/index.json
@@ -28,7 +28,10 @@
           1,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "bin_1x1_labeled-perspective-90.png",
+      "perspectiveImageUrl180": "bin_1x1_labeled-perspective-180.png",
+      "perspectiveImageUrl270": "bin_1x1_labeled-perspective-270.png"
     },
     {
       "id": "bin-1x2-labeled",
@@ -50,7 +53,10 @@
           2,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "bin_1x2_labeled-perspective-90.png",
+      "perspectiveImageUrl180": "bin_1x2_labeled-perspective-180.png",
+      "perspectiveImageUrl270": "bin_1x2_labeled-perspective-270.png"
     },
     {
       "id": "bin-1x3-labeled",
@@ -72,7 +78,10 @@
           3,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "bin_1x3_labeled-perspective-90.png",
+      "perspectiveImageUrl180": "bin_1x3_labeled-perspective-180.png",
+      "perspectiveImageUrl270": "bin_1x3_labeled-perspective-270.png"
     },
     {
       "id": "bin-1x4-labeled",
@@ -94,7 +103,10 @@
           4,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "bin_1x4_labeled-perspective-90.png",
+      "perspectiveImageUrl180": "bin_1x4_labeled-perspective-180.png",
+      "perspectiveImageUrl270": "bin_1x4_labeled-perspective-270.png"
     },
     {
       "id": "bin-1x5-labeled",
@@ -116,7 +128,10 @@
           5,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "bin_1x5_labeled-perspective-90.png",
+      "perspectiveImageUrl180": "bin_1x5_labeled-perspective-180.png",
+      "perspectiveImageUrl270": "bin_1x5_labeled-perspective-270.png"
     },
     {
       "id": "bin-2x1-labeled",
@@ -138,7 +153,10 @@
           1,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "bin_2x1_labeled-perspective-90.png",
+      "perspectiveImageUrl180": "bin_2x1_labeled-perspective-180.png",
+      "perspectiveImageUrl270": "bin_2x1_labeled-perspective-270.png"
     },
     {
       "id": "bin-2x2-labeled",
@@ -160,7 +178,10 @@
           2,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "bin_2x2_labeled-perspective-90.png",
+      "perspectiveImageUrl180": "bin_2x2_labeled-perspective-180.png",
+      "perspectiveImageUrl270": "bin_2x2_labeled-perspective-270.png"
     },
     {
       "id": "bin-2x3-labeled",
@@ -182,7 +203,10 @@
           3,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "bin_2x3_labeled-perspective-90.png",
+      "perspectiveImageUrl180": "bin_2x3_labeled-perspective-180.png",
+      "perspectiveImageUrl270": "bin_2x3_labeled-perspective-270.png"
     },
     {
       "id": "bin-2x4-labeled",
@@ -204,7 +228,10 @@
           4,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "bin_2x4_labeled-perspective-90.png",
+      "perspectiveImageUrl180": "bin_2x4_labeled-perspective-180.png",
+      "perspectiveImageUrl270": "bin_2x4_labeled-perspective-270.png"
     },
     {
       "id": "bin-2x5-labeled",
@@ -226,7 +253,10 @@
           5,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "bin_2x5_labeled-perspective-90.png",
+      "perspectiveImageUrl180": "bin_2x5_labeled-perspective-180.png",
+      "perspectiveImageUrl270": "bin_2x5_labeled-perspective-270.png"
     },
     {
       "id": "bin-3x1-labeled",
@@ -248,7 +278,10 @@
           1,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "bin_3x1_labeled-perspective-90.png",
+      "perspectiveImageUrl180": "bin_3x1_labeled-perspective-180.png",
+      "perspectiveImageUrl270": "bin_3x1_labeled-perspective-270.png"
     },
     {
       "id": "bin-3x2-labeled",
@@ -270,7 +303,10 @@
           2,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "bin_3x2_labeled-perspective-90.png",
+      "perspectiveImageUrl180": "bin_3x2_labeled-perspective-180.png",
+      "perspectiveImageUrl270": "bin_3x2_labeled-perspective-270.png"
     },
     {
       "id": "bin-3x3-labeled",
@@ -292,7 +328,10 @@
           3,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "bin_3x3_labeled-perspective-90.png",
+      "perspectiveImageUrl180": "bin_3x3_labeled-perspective-180.png",
+      "perspectiveImageUrl270": "bin_3x3_labeled-perspective-270.png"
     },
     {
       "id": "bin-3x4-labeled",
@@ -314,7 +353,10 @@
           4,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "bin_3x4_labeled-perspective-90.png",
+      "perspectiveImageUrl180": "bin_3x4_labeled-perspective-180.png",
+      "perspectiveImageUrl270": "bin_3x4_labeled-perspective-270.png"
     },
     {
       "id": "bin-3x5-labeled",
@@ -336,7 +378,10 @@
           5,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "bin_3x5_labeled-perspective-90.png",
+      "perspectiveImageUrl180": "bin_3x5_labeled-perspective-180.png",
+      "perspectiveImageUrl270": "bin_3x5_labeled-perspective-270.png"
     },
     {
       "id": "bin-4x1-labeled",
@@ -358,7 +403,10 @@
           1,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "bin_4x1_labeled-perspective-90.png",
+      "perspectiveImageUrl180": "bin_4x1_labeled-perspective-180.png",
+      "perspectiveImageUrl270": "bin_4x1_labeled-perspective-270.png"
     },
     {
       "id": "bin-4x2-labeled",
@@ -380,7 +428,10 @@
           2,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "bin_4x2_labeled-perspective-90.png",
+      "perspectiveImageUrl180": "bin_4x2_labeled-perspective-180.png",
+      "perspectiveImageUrl270": "bin_4x2_labeled-perspective-270.png"
     },
     {
       "id": "bin-4x3-labeled",
@@ -402,7 +453,10 @@
           3,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "bin_4x3_labeled-perspective-90.png",
+      "perspectiveImageUrl180": "bin_4x3_labeled-perspective-180.png",
+      "perspectiveImageUrl270": "bin_4x3_labeled-perspective-270.png"
     },
     {
       "id": "bin-4x4-labeled",
@@ -424,7 +478,10 @@
           4,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "bin_4x4_labeled-perspective-90.png",
+      "perspectiveImageUrl180": "bin_4x4_labeled-perspective-180.png",
+      "perspectiveImageUrl270": "bin_4x4_labeled-perspective-270.png"
     },
     {
       "id": "bin-4x5-labeled",
@@ -446,7 +503,10 @@
           5,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "bin_4x5_labeled-perspective-90.png",
+      "perspectiveImageUrl180": "bin_4x5_labeled-perspective-180.png",
+      "perspectiveImageUrl270": "bin_4x5_labeled-perspective-270.png"
     },
     {
       "id": "bin-5x1-labeled",
@@ -468,7 +528,10 @@
           1,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "bin_5x1_labeled-perspective-90.png",
+      "perspectiveImageUrl180": "bin_5x1_labeled-perspective-180.png",
+      "perspectiveImageUrl270": "bin_5x1_labeled-perspective-270.png"
     },
     {
       "id": "bin-5x2-labeled",
@@ -490,7 +553,10 @@
           2,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "bin_5x2_labeled-perspective-90.png",
+      "perspectiveImageUrl180": "bin_5x2_labeled-perspective-180.png",
+      "perspectiveImageUrl270": "bin_5x2_labeled-perspective-270.png"
     },
     {
       "id": "bin-5x3-labeled",
@@ -512,7 +578,10 @@
           3,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "bin_5x3_labeled-perspective-90.png",
+      "perspectiveImageUrl180": "bin_5x3_labeled-perspective-180.png",
+      "perspectiveImageUrl270": "bin_5x3_labeled-perspective-270.png"
     },
     {
       "id": "bin-5x4-labeled",
@@ -534,7 +603,10 @@
           4,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "bin_5x4_labeled-perspective-90.png",
+      "perspectiveImageUrl180": "bin_5x4_labeled-perspective-180.png",
+      "perspectiveImageUrl270": "bin_5x4_labeled-perspective-270.png"
     },
     {
       "id": "bin-5x5-labeled",
@@ -556,7 +628,10 @@
           5,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "bin_5x5_labeled-perspective-90.png",
+      "perspectiveImageUrl180": "bin_5x5_labeled-perspective-180.png",
+      "perspectiveImageUrl270": "bin_5x5_labeled-perspective-270.png"
     }
   ],
   "parameters": {

--- a/packages/app/public/libraries/bins_labeled/index.json
+++ b/packages/app/public/libraries/bins_labeled/index.json
@@ -7,19 +7,6 @@
     "fingerSlide",
     "wallCutout"
   ],
-  "gridfinityExtendedParams": {
-    "label_style": "normal",
-    "label_walls": [
-      0,
-      1,
-      0,
-      0
-    ],
-    "height": [
-      4,
-      0
-    ]
-  },
   "items": [
     {
       "id": "bin-1x1-labeled",
@@ -32,7 +19,7 @@
       ],
       "imageUrl": "bin_1x1_labeled.png",
       "perspectiveImageUrl": "bin_1x1_labeled-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           1,
           0
@@ -54,7 +41,7 @@
       ],
       "imageUrl": "bin_1x2_labeled.png",
       "perspectiveImageUrl": "bin_1x2_labeled-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           1,
           0
@@ -76,7 +63,7 @@
       ],
       "imageUrl": "bin_1x3_labeled.png",
       "perspectiveImageUrl": "bin_1x3_labeled-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           1,
           0
@@ -98,7 +85,7 @@
       ],
       "imageUrl": "bin_1x4_labeled.png",
       "perspectiveImageUrl": "bin_1x4_labeled-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           1,
           0
@@ -120,7 +107,7 @@
       ],
       "imageUrl": "bin_1x5_labeled.png",
       "perspectiveImageUrl": "bin_1x5_labeled-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           1,
           0
@@ -142,7 +129,7 @@
       ],
       "imageUrl": "bin_2x1_labeled.png",
       "perspectiveImageUrl": "bin_2x1_labeled-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           2,
           0
@@ -164,7 +151,7 @@
       ],
       "imageUrl": "bin_2x2_labeled.png",
       "perspectiveImageUrl": "bin_2x2_labeled-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           2,
           0
@@ -186,7 +173,7 @@
       ],
       "imageUrl": "bin_2x3_labeled.png",
       "perspectiveImageUrl": "bin_2x3_labeled-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           2,
           0
@@ -208,7 +195,7 @@
       ],
       "imageUrl": "bin_2x4_labeled.png",
       "perspectiveImageUrl": "bin_2x4_labeled-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           2,
           0
@@ -230,7 +217,7 @@
       ],
       "imageUrl": "bin_2x5_labeled.png",
       "perspectiveImageUrl": "bin_2x5_labeled-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           2,
           0
@@ -252,7 +239,7 @@
       ],
       "imageUrl": "bin_3x1_labeled.png",
       "perspectiveImageUrl": "bin_3x1_labeled-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           3,
           0
@@ -274,7 +261,7 @@
       ],
       "imageUrl": "bin_3x2_labeled.png",
       "perspectiveImageUrl": "bin_3x2_labeled-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           3,
           0
@@ -296,7 +283,7 @@
       ],
       "imageUrl": "bin_3x3_labeled.png",
       "perspectiveImageUrl": "bin_3x3_labeled-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           3,
           0
@@ -318,7 +305,7 @@
       ],
       "imageUrl": "bin_3x4_labeled.png",
       "perspectiveImageUrl": "bin_3x4_labeled-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           3,
           0
@@ -340,7 +327,7 @@
       ],
       "imageUrl": "bin_3x5_labeled.png",
       "perspectiveImageUrl": "bin_3x5_labeled-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           3,
           0
@@ -362,7 +349,7 @@
       ],
       "imageUrl": "bin_4x1_labeled.png",
       "perspectiveImageUrl": "bin_4x1_labeled-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           4,
           0
@@ -384,7 +371,7 @@
       ],
       "imageUrl": "bin_4x2_labeled.png",
       "perspectiveImageUrl": "bin_4x2_labeled-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           4,
           0
@@ -406,7 +393,7 @@
       ],
       "imageUrl": "bin_4x3_labeled.png",
       "perspectiveImageUrl": "bin_4x3_labeled-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           4,
           0
@@ -428,7 +415,7 @@
       ],
       "imageUrl": "bin_4x4_labeled.png",
       "perspectiveImageUrl": "bin_4x4_labeled-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           4,
           0
@@ -450,7 +437,7 @@
       ],
       "imageUrl": "bin_4x5_labeled.png",
       "perspectiveImageUrl": "bin_4x5_labeled-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           4,
           0
@@ -472,7 +459,7 @@
       ],
       "imageUrl": "bin_5x1_labeled.png",
       "perspectiveImageUrl": "bin_5x1_labeled-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           5,
           0
@@ -494,7 +481,7 @@
       ],
       "imageUrl": "bin_5x2_labeled.png",
       "perspectiveImageUrl": "bin_5x2_labeled-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           5,
           0
@@ -516,7 +503,7 @@
       ],
       "imageUrl": "bin_5x3_labeled.png",
       "perspectiveImageUrl": "bin_5x3_labeled-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           5,
           0
@@ -538,7 +525,7 @@
       ],
       "imageUrl": "bin_5x4_labeled.png",
       "perspectiveImageUrl": "bin_5x4_labeled-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           5,
           0
@@ -560,7 +547,7 @@
       ],
       "imageUrl": "bin_5x5_labeled.png",
       "perspectiveImageUrl": "bin_5x5_labeled-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           5,
           0
@@ -571,5 +558,18 @@
         ]
       }
     }
-  ]
+  ],
+  "parameters": {
+    "label_style": "normal",
+    "label_walls": [
+      0,
+      1,
+      0,
+      0
+    ],
+    "height": [
+      4,
+      0
+    ]
+  }
 }

--- a/packages/app/public/libraries/bins_standard/index.json
+++ b/packages/app/public/libraries/bins_standard/index.json
@@ -28,7 +28,10 @@
           1,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "bin_1x1-perspective-90.png",
+      "perspectiveImageUrl180": "bin_1x1-perspective-180.png",
+      "perspectiveImageUrl270": "bin_1x1-perspective-270.png"
     },
     {
       "id": "bin-1x2",
@@ -50,7 +53,10 @@
           2,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "bin_1x2-perspective-90.png",
+      "perspectiveImageUrl180": "bin_1x2-perspective-180.png",
+      "perspectiveImageUrl270": "bin_1x2-perspective-270.png"
     },
     {
       "id": "bin-1x3",
@@ -72,7 +78,10 @@
           3,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "bin_1x3-perspective-90.png",
+      "perspectiveImageUrl180": "bin_1x3-perspective-180.png",
+      "perspectiveImageUrl270": "bin_1x3-perspective-270.png"
     },
     {
       "id": "bin-1x4",
@@ -94,7 +103,10 @@
           4,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "bin_1x4-perspective-90.png",
+      "perspectiveImageUrl180": "bin_1x4-perspective-180.png",
+      "perspectiveImageUrl270": "bin_1x4-perspective-270.png"
     },
     {
       "id": "bin-1x5",
@@ -116,7 +128,10 @@
           5,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "bin_1x5-perspective-90.png",
+      "perspectiveImageUrl180": "bin_1x5-perspective-180.png",
+      "perspectiveImageUrl270": "bin_1x5-perspective-270.png"
     },
     {
       "id": "bin-2x1",
@@ -138,7 +153,10 @@
           1,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "bin_2x1-perspective-90.png",
+      "perspectiveImageUrl180": "bin_2x1-perspective-180.png",
+      "perspectiveImageUrl270": "bin_2x1-perspective-270.png"
     },
     {
       "id": "bin-2x2",
@@ -160,7 +178,10 @@
           2,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "bin_2x2-perspective-90.png",
+      "perspectiveImageUrl180": "bin_2x2-perspective-180.png",
+      "perspectiveImageUrl270": "bin_2x2-perspective-270.png"
     },
     {
       "id": "bin-2x3",
@@ -182,7 +203,10 @@
           3,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "bin_2x3-perspective-90.png",
+      "perspectiveImageUrl180": "bin_2x3-perspective-180.png",
+      "perspectiveImageUrl270": "bin_2x3-perspective-270.png"
     },
     {
       "id": "bin-2x4",
@@ -204,7 +228,10 @@
           4,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "bin_2x4-perspective-90.png",
+      "perspectiveImageUrl180": "bin_2x4-perspective-180.png",
+      "perspectiveImageUrl270": "bin_2x4-perspective-270.png"
     },
     {
       "id": "bin-2x5",
@@ -226,7 +253,10 @@
           5,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "bin_2x5-perspective-90.png",
+      "perspectiveImageUrl180": "bin_2x5-perspective-180.png",
+      "perspectiveImageUrl270": "bin_2x5-perspective-270.png"
     },
     {
       "id": "bin-3x1",
@@ -248,7 +278,10 @@
           1,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "bin_3x1-perspective-90.png",
+      "perspectiveImageUrl180": "bin_3x1-perspective-180.png",
+      "perspectiveImageUrl270": "bin_3x1-perspective-270.png"
     },
     {
       "id": "bin-3x2",
@@ -270,7 +303,10 @@
           2,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "bin_3x2-perspective-90.png",
+      "perspectiveImageUrl180": "bin_3x2-perspective-180.png",
+      "perspectiveImageUrl270": "bin_3x2-perspective-270.png"
     },
     {
       "id": "bin-3x3",
@@ -292,7 +328,10 @@
           3,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "bin_3x3-perspective-90.png",
+      "perspectiveImageUrl180": "bin_3x3-perspective-180.png",
+      "perspectiveImageUrl270": "bin_3x3-perspective-270.png"
     },
     {
       "id": "bin-3x4",
@@ -314,7 +353,10 @@
           4,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "bin_3x4-perspective-90.png",
+      "perspectiveImageUrl180": "bin_3x4-perspective-180.png",
+      "perspectiveImageUrl270": "bin_3x4-perspective-270.png"
     },
     {
       "id": "bin-3x5",
@@ -336,7 +378,10 @@
           5,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "bin_3x5-perspective-90.png",
+      "perspectiveImageUrl180": "bin_3x5-perspective-180.png",
+      "perspectiveImageUrl270": "bin_3x5-perspective-270.png"
     },
     {
       "id": "bin-4x1",
@@ -358,7 +403,10 @@
           1,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "bin_4x1-perspective-90.png",
+      "perspectiveImageUrl180": "bin_4x1-perspective-180.png",
+      "perspectiveImageUrl270": "bin_4x1-perspective-270.png"
     },
     {
       "id": "bin-4x2",
@@ -380,7 +428,10 @@
           2,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "bin_4x2-perspective-90.png",
+      "perspectiveImageUrl180": "bin_4x2-perspective-180.png",
+      "perspectiveImageUrl270": "bin_4x2-perspective-270.png"
     },
     {
       "id": "bin-4x3",
@@ -402,7 +453,10 @@
           3,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "bin_4x3-perspective-90.png",
+      "perspectiveImageUrl180": "bin_4x3-perspective-180.png",
+      "perspectiveImageUrl270": "bin_4x3-perspective-270.png"
     },
     {
       "id": "bin-4x4",
@@ -424,7 +478,10 @@
           4,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "bin_4x4-perspective-90.png",
+      "perspectiveImageUrl180": "bin_4x4-perspective-180.png",
+      "perspectiveImageUrl270": "bin_4x4-perspective-270.png"
     },
     {
       "id": "bin-4x5",
@@ -446,7 +503,10 @@
           5,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "bin_4x5-perspective-90.png",
+      "perspectiveImageUrl180": "bin_4x5-perspective-180.png",
+      "perspectiveImageUrl270": "bin_4x5-perspective-270.png"
     },
     {
       "id": "bin-5x1",
@@ -468,7 +528,10 @@
           1,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "bin_5x1-perspective-90.png",
+      "perspectiveImageUrl180": "bin_5x1-perspective-180.png",
+      "perspectiveImageUrl270": "bin_5x1-perspective-270.png"
     },
     {
       "id": "bin-5x2",
@@ -490,7 +553,10 @@
           2,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "bin_5x2-perspective-90.png",
+      "perspectiveImageUrl180": "bin_5x2-perspective-180.png",
+      "perspectiveImageUrl270": "bin_5x2-perspective-270.png"
     },
     {
       "id": "bin-5x3",
@@ -512,7 +578,10 @@
           3,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "bin_5x3-perspective-90.png",
+      "perspectiveImageUrl180": "bin_5x3-perspective-180.png",
+      "perspectiveImageUrl270": "bin_5x3-perspective-270.png"
     },
     {
       "id": "bin-5x4",
@@ -534,7 +603,10 @@
           4,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "bin_5x4-perspective-90.png",
+      "perspectiveImageUrl180": "bin_5x4-perspective-180.png",
+      "perspectiveImageUrl270": "bin_5x4-perspective-270.png"
     },
     {
       "id": "bin-5x5",
@@ -556,7 +628,10 @@
           5,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "bin_5x5-perspective-90.png",
+      "perspectiveImageUrl180": "bin_5x5-perspective-180.png",
+      "perspectiveImageUrl270": "bin_5x5-perspective-270.png"
     }
   ],
   "parameters": {

--- a/packages/app/public/libraries/bins_standard/index.json
+++ b/packages/app/public/libraries/bins_standard/index.json
@@ -2,10 +2,10 @@
   "version": "1.0.0",
   "baseModel": "gridfinity_basic_cup.scad",
   "customizableFields": [
-    "lipStyle",
-    "wallPattern",
-    "fingerSlide",
-    "wallCutout"
+    { "field": "wallPattern", "label": "Wall Pattern", "options": ["none", "grid", "hexgrid", "brick"] },
+    { "field": "lipStyle",    "label": "Lip Style",    "options": ["normal", "reduced", "minimum", "none"] },
+    { "field": "fingerSlide", "label": "Finger Slide", "options": ["none", "rounded", "chamfered"] },
+    { "field": "wallCutout",  "label": "Wall Cutout",  "options": ["none", "vertical", "horizontal", "both"] }
   ],
   "items": [
     {

--- a/packages/app/public/libraries/bins_standard/index.json
+++ b/packages/app/public/libraries/bins_standard/index.json
@@ -7,12 +7,6 @@
     "fingerSlide",
     "wallCutout"
   ],
-  "gridfinityExtendedParams": {
-    "height": [
-      4,
-      0
-    ]
-  },
   "items": [
     {
       "id": "bin-1x1",
@@ -25,7 +19,7 @@
       ],
       "imageUrl": "bin_1x1.png",
       "perspectiveImageUrl": "bin_1x1-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           1,
           0
@@ -47,7 +41,7 @@
       ],
       "imageUrl": "bin_1x2.png",
       "perspectiveImageUrl": "bin_1x2-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           1,
           0
@@ -69,7 +63,7 @@
       ],
       "imageUrl": "bin_1x3.png",
       "perspectiveImageUrl": "bin_1x3-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           1,
           0
@@ -91,7 +85,7 @@
       ],
       "imageUrl": "bin_1x4.png",
       "perspectiveImageUrl": "bin_1x4-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           1,
           0
@@ -113,7 +107,7 @@
       ],
       "imageUrl": "bin_1x5.png",
       "perspectiveImageUrl": "bin_1x5-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           1,
           0
@@ -135,7 +129,7 @@
       ],
       "imageUrl": "bin_2x1.png",
       "perspectiveImageUrl": "bin_2x1-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           2,
           0
@@ -157,7 +151,7 @@
       ],
       "imageUrl": "bin_2x2.png",
       "perspectiveImageUrl": "bin_2x2-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           2,
           0
@@ -179,7 +173,7 @@
       ],
       "imageUrl": "bin_2x3.png",
       "perspectiveImageUrl": "bin_2x3-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           2,
           0
@@ -201,7 +195,7 @@
       ],
       "imageUrl": "bin_2x4.png",
       "perspectiveImageUrl": "bin_2x4-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           2,
           0
@@ -223,7 +217,7 @@
       ],
       "imageUrl": "bin_2x5.png",
       "perspectiveImageUrl": "bin_2x5-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           2,
           0
@@ -245,7 +239,7 @@
       ],
       "imageUrl": "bin_3x1.png",
       "perspectiveImageUrl": "bin_3x1-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           3,
           0
@@ -267,7 +261,7 @@
       ],
       "imageUrl": "bin_3x2.png",
       "perspectiveImageUrl": "bin_3x2-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           3,
           0
@@ -289,7 +283,7 @@
       ],
       "imageUrl": "bin_3x3.png",
       "perspectiveImageUrl": "bin_3x3-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           3,
           0
@@ -311,7 +305,7 @@
       ],
       "imageUrl": "bin_3x4.png",
       "perspectiveImageUrl": "bin_3x4-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           3,
           0
@@ -333,7 +327,7 @@
       ],
       "imageUrl": "bin_3x5.png",
       "perspectiveImageUrl": "bin_3x5-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           3,
           0
@@ -355,7 +349,7 @@
       ],
       "imageUrl": "bin_4x1.png",
       "perspectiveImageUrl": "bin_4x1-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           4,
           0
@@ -377,7 +371,7 @@
       ],
       "imageUrl": "bin_4x2.png",
       "perspectiveImageUrl": "bin_4x2-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           4,
           0
@@ -399,7 +393,7 @@
       ],
       "imageUrl": "bin_4x3.png",
       "perspectiveImageUrl": "bin_4x3-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           4,
           0
@@ -421,7 +415,7 @@
       ],
       "imageUrl": "bin_4x4.png",
       "perspectiveImageUrl": "bin_4x4-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           4,
           0
@@ -443,7 +437,7 @@
       ],
       "imageUrl": "bin_4x5.png",
       "perspectiveImageUrl": "bin_4x5-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           4,
           0
@@ -465,7 +459,7 @@
       ],
       "imageUrl": "bin_5x1.png",
       "perspectiveImageUrl": "bin_5x1-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           5,
           0
@@ -487,7 +481,7 @@
       ],
       "imageUrl": "bin_5x2.png",
       "perspectiveImageUrl": "bin_5x2-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           5,
           0
@@ -509,7 +503,7 @@
       ],
       "imageUrl": "bin_5x3.png",
       "perspectiveImageUrl": "bin_5x3-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           5,
           0
@@ -531,7 +525,7 @@
       ],
       "imageUrl": "bin_5x4.png",
       "perspectiveImageUrl": "bin_5x4-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           5,
           0
@@ -553,7 +547,7 @@
       ],
       "imageUrl": "bin_5x5.png",
       "perspectiveImageUrl": "bin_5x5-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           5,
           0
@@ -564,5 +558,11 @@
         ]
       }
     }
-  ]
+  ],
+  "parameters": {
+    "height": [
+      4,
+      0
+    ]
+  }
 }

--- a/packages/app/public/libraries/shadowbox/index.json
+++ b/packages/app/public/libraries/shadowbox/index.json
@@ -28,7 +28,10 @@
           2,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "shadowbox_2x2-perspective-90.png",
+      "perspectiveImageUrl180": "shadowbox_2x2-perspective-180.png",
+      "perspectiveImageUrl270": "shadowbox_2x2-perspective-270.png"
     },
     {
       "id": "shadowbox-2x3",
@@ -50,7 +53,10 @@
           3,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "shadowbox_2x3-perspective-90.png",
+      "perspectiveImageUrl180": "shadowbox_2x3-perspective-180.png",
+      "perspectiveImageUrl270": "shadowbox_2x3-perspective-270.png"
     },
     {
       "id": "shadowbox-2x4",
@@ -72,7 +78,10 @@
           4,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "shadowbox_2x4-perspective-90.png",
+      "perspectiveImageUrl180": "shadowbox_2x4-perspective-180.png",
+      "perspectiveImageUrl270": "shadowbox_2x4-perspective-270.png"
     },
     {
       "id": "shadowbox-2x5",
@@ -94,7 +103,10 @@
           5,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "shadowbox_2x5-perspective-90.png",
+      "perspectiveImageUrl180": "shadowbox_2x5-perspective-180.png",
+      "perspectiveImageUrl270": "shadowbox_2x5-perspective-270.png"
     },
     {
       "id": "shadowbox-3x2",
@@ -116,7 +128,10 @@
           2,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "shadowbox_3x2-perspective-90.png",
+      "perspectiveImageUrl180": "shadowbox_3x2-perspective-180.png",
+      "perspectiveImageUrl270": "shadowbox_3x2-perspective-270.png"
     },
     {
       "id": "shadowbox-3x3",
@@ -138,7 +153,10 @@
           3,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "shadowbox_3x3-perspective-90.png",
+      "perspectiveImageUrl180": "shadowbox_3x3-perspective-180.png",
+      "perspectiveImageUrl270": "shadowbox_3x3-perspective-270.png"
     },
     {
       "id": "shadowbox-3x4",
@@ -160,7 +178,10 @@
           4,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "shadowbox_3x4-perspective-90.png",
+      "perspectiveImageUrl180": "shadowbox_3x4-perspective-180.png",
+      "perspectiveImageUrl270": "shadowbox_3x4-perspective-270.png"
     },
     {
       "id": "shadowbox-3x5",
@@ -182,7 +203,10 @@
           5,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "shadowbox_3x5-perspective-90.png",
+      "perspectiveImageUrl180": "shadowbox_3x5-perspective-180.png",
+      "perspectiveImageUrl270": "shadowbox_3x5-perspective-270.png"
     },
     {
       "id": "shadowbox-4x2",
@@ -204,7 +228,10 @@
           2,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "shadowbox_4x2-perspective-90.png",
+      "perspectiveImageUrl180": "shadowbox_4x2-perspective-180.png",
+      "perspectiveImageUrl270": "shadowbox_4x2-perspective-270.png"
     },
     {
       "id": "shadowbox-4x3",
@@ -226,7 +253,10 @@
           3,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "shadowbox_4x3-perspective-90.png",
+      "perspectiveImageUrl180": "shadowbox_4x3-perspective-180.png",
+      "perspectiveImageUrl270": "shadowbox_4x3-perspective-270.png"
     },
     {
       "id": "shadowbox-4x4",
@@ -248,7 +278,10 @@
           4,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "shadowbox_4x4-perspective-90.png",
+      "perspectiveImageUrl180": "shadowbox_4x4-perspective-180.png",
+      "perspectiveImageUrl270": "shadowbox_4x4-perspective-270.png"
     },
     {
       "id": "shadowbox-4x5",
@@ -270,7 +303,10 @@
           5,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "shadowbox_4x5-perspective-90.png",
+      "perspectiveImageUrl180": "shadowbox_4x5-perspective-180.png",
+      "perspectiveImageUrl270": "shadowbox_4x5-perspective-270.png"
     },
     {
       "id": "shadowbox-5x2",
@@ -292,7 +328,10 @@
           2,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "shadowbox_5x2-perspective-90.png",
+      "perspectiveImageUrl180": "shadowbox_5x2-perspective-180.png",
+      "perspectiveImageUrl270": "shadowbox_5x2-perspective-270.png"
     },
     {
       "id": "shadowbox-5x3",
@@ -314,7 +353,10 @@
           3,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "shadowbox_5x3-perspective-90.png",
+      "perspectiveImageUrl180": "shadowbox_5x3-perspective-180.png",
+      "perspectiveImageUrl270": "shadowbox_5x3-perspective-270.png"
     },
     {
       "id": "shadowbox-5x4",
@@ -336,7 +378,10 @@
           4,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "shadowbox_5x4-perspective-90.png",
+      "perspectiveImageUrl180": "shadowbox_5x4-perspective-180.png",
+      "perspectiveImageUrl270": "shadowbox_5x4-perspective-270.png"
     },
     {
       "id": "shadowbox-5x5",
@@ -358,7 +403,10 @@
           5,
           0
         ]
-      }
+      },
+      "perspectiveImageUrl90": "shadowbox_5x5-perspective-90.png",
+      "perspectiveImageUrl180": "shadowbox_5x5-perspective-180.png",
+      "perspectiveImageUrl270": "shadowbox_5x5-perspective-270.png"
     }
   ],
   "parameters": {

--- a/packages/app/public/libraries/shadowbox/index.json
+++ b/packages/app/public/libraries/shadowbox/index.json
@@ -2,10 +2,10 @@
   "version": "1.0.0",
   "baseModel": "gridfinity_basic_cup.scad",
   "customizableFields": [
-    "lipStyle",
-    "fingerSlide",
-    "wallCutout",
-    "height"
+    { "field": "lipStyle",    "label": "Lip Style",    "options": ["normal", "reduced", "minimum", "none"] },
+    { "field": "fingerSlide", "label": "Finger Slide", "options": ["none", "rounded", "chamfered"] },
+    { "field": "wallCutout",  "label": "Wall Cutout",  "options": ["none", "vertical", "horizontal", "both"] },
+    { "field": "height",      "label": "Height",       "min": 1, "max": 20 }
   ],
   "items": [
     {

--- a/packages/app/public/libraries/shadowbox/index.json
+++ b/packages/app/public/libraries/shadowbox/index.json
@@ -7,13 +7,6 @@
     "wallCutout",
     "height"
   ],
-  "gridfinityExtendedParams": {
-    "height": [
-      4,
-      0
-    ],
-    "filled_in": "enabled"
-  },
   "items": [
     {
       "id": "shadowbox-2x2",
@@ -26,7 +19,7 @@
       ],
       "imageUrl": "shadowbox_2x2.png",
       "perspectiveImageUrl": "shadowbox_2x2-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           2,
           0
@@ -48,7 +41,7 @@
       ],
       "imageUrl": "shadowbox_2x3.png",
       "perspectiveImageUrl": "shadowbox_2x3-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           2,
           0
@@ -70,7 +63,7 @@
       ],
       "imageUrl": "shadowbox_2x4.png",
       "perspectiveImageUrl": "shadowbox_2x4-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           2,
           0
@@ -92,7 +85,7 @@
       ],
       "imageUrl": "shadowbox_2x5.png",
       "perspectiveImageUrl": "shadowbox_2x5-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           2,
           0
@@ -114,7 +107,7 @@
       ],
       "imageUrl": "shadowbox_3x2.png",
       "perspectiveImageUrl": "shadowbox_3x2-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           3,
           0
@@ -136,7 +129,7 @@
       ],
       "imageUrl": "shadowbox_3x3.png",
       "perspectiveImageUrl": "shadowbox_3x3-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           3,
           0
@@ -158,7 +151,7 @@
       ],
       "imageUrl": "shadowbox_3x4.png",
       "perspectiveImageUrl": "shadowbox_3x4-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           3,
           0
@@ -180,7 +173,7 @@
       ],
       "imageUrl": "shadowbox_3x5.png",
       "perspectiveImageUrl": "shadowbox_3x5-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           3,
           0
@@ -202,7 +195,7 @@
       ],
       "imageUrl": "shadowbox_4x2.png",
       "perspectiveImageUrl": "shadowbox_4x2-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           4,
           0
@@ -224,7 +217,7 @@
       ],
       "imageUrl": "shadowbox_4x3.png",
       "perspectiveImageUrl": "shadowbox_4x3-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           4,
           0
@@ -246,7 +239,7 @@
       ],
       "imageUrl": "shadowbox_4x4.png",
       "perspectiveImageUrl": "shadowbox_4x4-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           4,
           0
@@ -268,7 +261,7 @@
       ],
       "imageUrl": "shadowbox_4x5.png",
       "perspectiveImageUrl": "shadowbox_4x5-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           4,
           0
@@ -290,7 +283,7 @@
       ],
       "imageUrl": "shadowbox_5x2.png",
       "perspectiveImageUrl": "shadowbox_5x2-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           5,
           0
@@ -312,7 +305,7 @@
       ],
       "imageUrl": "shadowbox_5x3.png",
       "perspectiveImageUrl": "shadowbox_5x3-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           5,
           0
@@ -334,7 +327,7 @@
       ],
       "imageUrl": "shadowbox_5x4.png",
       "perspectiveImageUrl": "shadowbox_5x4-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           5,
           0
@@ -356,7 +349,7 @@
       ],
       "imageUrl": "shadowbox_5x5.png",
       "perspectiveImageUrl": "shadowbox_5x5-perspective.png",
-      "gridfinityExtendedParams": {
+      "parameters": {
         "width": [
           5,
           0
@@ -367,5 +360,12 @@
         ]
       }
     }
-  ]
+  ],
+  "parameters": {
+    "height": [
+      4,
+      0
+    ],
+    "filled_in": "enabled"
+  }
 }

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -201,7 +201,7 @@ const mockGetItemById = vi.fn((id: string): LibraryItem | undefined => {
   return undefined;
 });
 
-const mockGetLibraryMeta = vi.fn().mockResolvedValue({ customizableFields: [], customizationDefaults: {} });
+const mockGetLibraryMeta = vi.fn().mockResolvedValue({ customizableFields: [], parameters: {} });
 vi.mock('./hooks/useLibraryData', () => ({
   useLibraryData: () => ({
     items: [testItem, testItem2x1],

--- a/packages/app/src/AppShell.test.tsx
+++ b/packages/app/src/AppShell.test.tsx
@@ -83,7 +83,7 @@ vi.mock('./contexts/WorkspaceContext', () => ({
     getLibraryMeta: vi.fn(),
     refreshLibraries: vi.fn(),
     refreshLibrary: vi.fn(),
-    selectedLibraryMeta: { customizableFields: [], customizationDefaults: {} },
+    selectedLibraryMeta: { customizableFields: [], parameters: {} },
     loadLayout: vi.fn(),
     handleSubmitLayout: vi.fn(),
     handleWithdrawLayout: vi.fn(),

--- a/packages/app/src/api/adapters/api.adapter.ts
+++ b/packages/app/src/api/adapters/api.adapter.ts
@@ -28,7 +28,7 @@ export class ApiAdapter implements DataSourceAdapter {
     const json = await response.json();
 
     const meta = await this.getLibraryMeta(libraryId);
-    const libraryDefaults = meta.gridfinityExtendedParams;
+    const libraryDefaults = meta.parameters;
 
     return json.data.map((item: Record<string, unknown>) => ({
       id: item.id as string,
@@ -41,9 +41,9 @@ export class ApiAdapter implements DataSourceAdapter {
       stlFile: (item.stlFile as string | null | undefined) ?? undefined,
       imageUrl: item.imagePath as string | undefined,
       perspectiveImageUrl: item.perspectiveImagePath as string | undefined,
-      gridfinityExtendedParams: mergeGeneratorParams(
+      parameters: mergeGeneratorParams(
         libraryDefaults,
-        (item.gridfinityExtendedParams as Record<string, unknown> | undefined)
+        (item.parameters as Record<string, unknown> | undefined)
       ),
     }));
   }
@@ -51,19 +51,19 @@ export class ApiAdapter implements DataSourceAdapter {
   async getLibraryMeta(libraryId: string): Promise<LibraryMeta> {
     try {
       const manifestResponse = await fetch('/libraries/manifest.json');
-      if (!manifestResponse.ok) return { customizableFields: [], gridfinityExtendedParams: {} };
+      if (!manifestResponse.ok) return { customizableFields: [], parameters: {} };
       const manifest = await manifestResponse.json();
       const lib = manifest.libraries?.find((l: { id: string }) => l.id === libraryId);
-      if (!lib) return { customizableFields: [], gridfinityExtendedParams: {} };
+      if (!lib) return { customizableFields: [], parameters: {} };
       const indexResponse = await fetch(lib.path);
-      if (!indexResponse.ok) return { customizableFields: [], gridfinityExtendedParams: {} };
+      if (!indexResponse.ok) return { customizableFields: [], parameters: {} };
       const data = await indexResponse.json();
       return {
         customizableFields: data.customizableFields ?? [],
-        gridfinityExtendedParams: data.gridfinityExtendedParams ?? {},
+        parameters: data.parameters ?? {},
       };
     } catch {
-      return { customizableFields: [], gridfinityExtendedParams: {} };
+      return { customizableFields: [], parameters: {} };
     }
   }
 

--- a/packages/app/src/api/adapters/static.adapter.ts
+++ b/packages/app/src/api/adapters/static.adapter.ts
@@ -82,9 +82,4 @@ export class StaticAdapter implements DataSourceAdapter {
     this.manifestCache = await response.json();
     return this.manifestCache!;
   }
-
-  clearCache(): void {
-    this.manifestCache = null;
-    this.metaCache.clear();
-  }
 }

--- a/packages/app/src/api/adapters/static.adapter.ts
+++ b/packages/app/src/api/adapters/static.adapter.ts
@@ -39,12 +39,12 @@ export class StaticAdapter implements DataSourceAdapter {
     const response = await fetch(lib.path);
     if (!response.ok) throw new Error(`Failed to fetch library ${libraryId}`);
     const data: LibraryIndex = await response.json();
-    const libraryDefaults = data.gridfinityExtendedParams ?? {};
+    const libraryDefaults = data.parameters ?? {};
 
     return (data.items ?? []).map((item) => ({
       ...item,
       libraryId,
-      gridfinityExtendedParams: mergeGeneratorParams(libraryDefaults, item.gridfinityExtendedParams),
+      parameters: mergeGeneratorParams(libraryDefaults, item.parameters),
     }));
   }
 
@@ -52,19 +52,19 @@ export class StaticAdapter implements DataSourceAdapter {
     if (this.metaCache.has(libraryId)) return this.metaCache.get(libraryId)!;
     const manifest = await this.fetchManifest();
     const lib = manifest.libraries.find((l) => l.id === libraryId);
-    if (!lib) return { customizableFields: [], gridfinityExtendedParams: {} };
+    if (!lib) return { customizableFields: [], parameters: {} };
     try {
       const response = await fetch(lib.path);
-      if (!response.ok) return { customizableFields: [], gridfinityExtendedParams: {} };
+      if (!response.ok) return { customizableFields: [], parameters: {} };
       const data: LibraryIndex = await response.json();
       const meta: LibraryMeta = {
         customizableFields: data.customizableFields ?? [],
-        gridfinityExtendedParams: data.gridfinityExtendedParams ?? {},
+        parameters: data.parameters ?? {},
       };
       this.metaCache.set(libraryId, meta);
       return meta;
     } catch {
-      return { customizableFields: [], gridfinityExtendedParams: {} };
+      return { customizableFields: [], parameters: {} };
     }
   }
 

--- a/packages/app/src/api/admin.api.ts
+++ b/packages/app/src/api/admin.api.ts
@@ -1,25 +1,12 @@
 import type { ApiLayout, ApiListResponse } from '@gridfinity/shared';
-
-const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? 'http://localhost:3001/api/v1';
-
-async function adminFetch<T>(path: string, accessToken: string): Promise<T> {
-  const response = await fetch(`${API_BASE_URL}${path}`, {
-    headers: { Authorization: `Bearer ${accessToken}` },
-  });
-  if (!response.ok) {
-    const errorBody = await response.json().catch(() => null);
-    const message = (errorBody?.error?.message as string | undefined) ?? `Request failed with status ${response.status}`;
-    throw new Error(message);
-  }
-  return response.json() as Promise<T>;
-}
+import { apiFetch } from './apiClient';
 
 export async function fetchAdminUsers(accessToken: string): Promise<Array<{ id: number; username: string }>> {
-  const result = await adminFetch<{ data: Array<{ id: number; username: string }> }>('/admin/users', accessToken);
+  const result = await apiFetch<{ data: Array<{ id: number; username: string }> }>('/admin/users', {}, accessToken);
   return result.data;
 }
 
 export async function fetchAdminUserLayouts(accessToken: string, userId: number): Promise<ApiLayout[]> {
-  const result = await adminFetch<ApiListResponse<ApiLayout>>(`/admin/layouts?userId=${userId}`, accessToken);
+  const result = await apiFetch<ApiListResponse<ApiLayout>>(`/admin/layouts?userId=${userId}`, {}, accessToken);
   return result.data;
 }

--- a/packages/app/src/api/apiClient.ts
+++ b/packages/app/src/api/apiClient.ts
@@ -1,14 +1,13 @@
 export const API_BASE_URL =
   (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? 'http://localhost:3001/api/v1';
 
-/**
- * Shared error-handling fetch wrapper used by the authenticated API modules.
- *
- * - Merges the caller-supplied headers with an optional Authorization header.
- * - Throws an Error with the server's `error.message` on non-OK responses.
- * - Returns `undefined as T` for 204 No Content.
- * - Returns `response.json()` otherwise.
- */
+export class ApiError extends Error {
+  constructor(message: string, public readonly status: number) {
+    super(message);
+    this.name = 'ApiError';
+  }
+}
+
 export async function apiFetch<T>(
   path: string,
   options: RequestInit = {},
@@ -30,7 +29,7 @@ export async function apiFetch<T>(
     const errorBody = await response.json().catch(() => null) as { error?: { message?: string } } | null;
     const message =
       errorBody?.error?.message ?? `Request failed with status ${response.status}`;
-    throw new Error(message);
+    throw new ApiError(message, response.status);
   }
 
   if (response.status === 204) {

--- a/packages/app/src/api/apiClient.ts
+++ b/packages/app/src/api/apiClient.ts
@@ -2,9 +2,11 @@ export const API_BASE_URL =
   (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? 'http://localhost:3001/api/v1';
 
 export class ApiError extends Error {
-  constructor(message: string, public readonly status: number) {
+  readonly status: number;
+  constructor(message: string, status: number) {
     super(message);
     this.name = 'ApiError';
+    this.status = status;
   }
 }
 

--- a/packages/app/src/api/apiClient.ts
+++ b/packages/app/src/api/apiClient.ts
@@ -1,0 +1,41 @@
+export const API_BASE_URL =
+  (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? 'http://localhost:3001/api/v1';
+
+/**
+ * Shared error-handling fetch wrapper used by the authenticated API modules.
+ *
+ * - Merges the caller-supplied headers with an optional Authorization header.
+ * - Throws an Error with the server's `error.message` on non-OK responses.
+ * - Returns `undefined as T` for 204 No Content.
+ * - Returns `response.json()` otherwise.
+ */
+export async function apiFetch<T>(
+  path: string,
+  options: RequestInit = {},
+  accessToken?: string,
+): Promise<T> {
+  const authHeader: Record<string, string> = accessToken
+    ? { Authorization: `Bearer ${accessToken}` }
+    : {};
+
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    ...options,
+    headers: {
+      ...authHeader,
+      ...(options.headers as Record<string, string>),
+    },
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.json().catch(() => null) as { error?: { message?: string } } | null;
+    const message =
+      errorBody?.error?.message ?? `Request failed with status ${response.status}`;
+    throw new Error(message);
+  }
+
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  return response.json() as Promise<T>;
+}

--- a/packages/app/src/api/auth.api.ts
+++ b/packages/app/src/api/auth.api.ts
@@ -1,6 +1,5 @@
 import type { ApiResponse, AuthResponse, TokenResponse, ApiUser } from '@gridfinity/shared';
-
-const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? '/api/v1';
+import { API_BASE_URL } from './apiClient';
 
 async function authFetch<T>(
   path: string,

--- a/packages/app/src/api/bomGeneration.api.ts
+++ b/packages/app/src/api/bomGeneration.api.ts
@@ -1,5 +1,5 @@
 import type { ApiResponse, ApiBomGeneration, BOMItem } from '@gridfinity/shared';
-import { apiFetch, API_BASE_URL } from './apiClient';
+import { apiFetch, API_BASE_URL, ApiError } from './apiClient';
 
 const JSON_HEADERS = { 'Content-Type': 'application/json' };
 
@@ -21,7 +21,7 @@ export async function getBomGeneration(layoutId: number, accessToken: string): P
     );
     return result.data;
   } catch (err) {
-    if (err instanceof Error && err.message.includes('404')) return null;
+    if (err instanceof ApiError && err.status === 404) return null;
     throw err;
   }
 }

--- a/packages/app/src/api/bomGeneration.api.ts
+++ b/packages/app/src/api/bomGeneration.api.ts
@@ -1,29 +1,12 @@
 import type { ApiResponse, ApiBomGeneration, BOMItem } from '@gridfinity/shared';
+import { apiFetch, API_BASE_URL } from './apiClient';
 
-const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? 'http://localhost:3001/api/v1';
-
-async function genFetch<T>(path: string, options: RequestInit = {}, accessToken?: string): Promise<T> {
-  const headers: Record<string, string> = {
-    'Content-Type': 'application/json',
-    ...(options.headers as Record<string, string>),
-  };
-  if (accessToken) headers.Authorization = `Bearer ${accessToken}`;
-
-  const response = await fetch(`${API_BASE_URL}${path}`, { ...options, headers });
-
-  if (!response.ok) {
-    const errorBody = await response.json().catch(() => null);
-    const message = (errorBody?.error?.message as string | undefined) ?? `Request failed with status ${response.status}`;
-    throw new Error(message);
-  }
-  if (response.status === 204) return undefined as T;
-  return response.json() as Promise<T>;
-}
+const JSON_HEADERS = { 'Content-Type': 'application/json' };
 
 export async function triggerBomGeneration(layoutId: number, bomItems: BOMItem[], accessToken: string): Promise<ApiBomGeneration> {
-  const result = await genFetch<ApiResponse<ApiBomGeneration>>(
+  const result = await apiFetch<ApiResponse<ApiBomGeneration>>(
     `/bom/generate/${layoutId}`,
-    { method: 'POST', body: JSON.stringify({ bomItems }) },
+    { method: 'POST', headers: JSON_HEADERS, body: JSON.stringify({ bomItems }) },
     accessToken,
   );
   return result.data;
@@ -31,9 +14,9 @@ export async function triggerBomGeneration(layoutId: number, bomItems: BOMItem[]
 
 export async function getBomGeneration(layoutId: number, accessToken: string): Promise<ApiBomGeneration | null> {
   try {
-    const result = await genFetch<ApiResponse<ApiBomGeneration>>(
+    const result = await apiFetch<ApiResponse<ApiBomGeneration>>(
       `/bom/generation/${layoutId}`,
-      { method: 'GET' },
+      { method: 'GET', headers: JSON_HEADERS },
       accessToken,
     );
     return result.data;

--- a/packages/app/src/api/layouts.api.ts
+++ b/packages/app/src/api/layouts.api.ts
@@ -6,35 +6,9 @@ import type {
   CreateLayoutRequest,
   UpdateLayoutMetaRequest,
 } from '@gridfinity/shared';
+import { apiFetch } from './apiClient';
 
-const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? 'http://localhost:3001/api/v1';
-
-async function layoutFetch<T>(
-  path: string,
-  accessToken: string,
-  options: RequestInit = {},
-): Promise<T> {
-  const response = await fetch(`${API_BASE_URL}${path}`, {
-    ...options,
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${accessToken}`,
-      ...options.headers,
-    },
-  });
-
-  if (!response.ok) {
-    const errorBody = await response.json().catch(() => null);
-    const message = errorBody?.error?.message ?? `Request failed with status ${response.status}`;
-    throw new Error(message);
-  }
-
-  if (response.status === 204) {
-    return undefined as T;
-  }
-
-  return response.json();
-}
+const JSON_HEADERS = { 'Content-Type': 'application/json' };
 
 export async function fetchLayouts(
   accessToken: string,
@@ -47,15 +21,16 @@ export async function fetchLayouts(
   const query = params.toString();
   const path = `/layouts${query ? `?${query}` : ''}`;
 
-  return layoutFetch<ApiListResponse<ApiLayout>>(path, accessToken);
+  return apiFetch<ApiListResponse<ApiLayout>>(path, { headers: JSON_HEADERS }, accessToken);
 }
 
 export async function fetchLayout(
   accessToken: string,
   id: number,
 ): Promise<ApiLayoutDetail> {
-  const result = await layoutFetch<ApiResponse<ApiLayoutDetail>>(
+  const result = await apiFetch<ApiResponse<ApiLayoutDetail>>(
     `/layouts/${id}`,
+    { headers: JSON_HEADERS },
     accessToken,
   );
   return result.data;
@@ -65,13 +40,10 @@ export async function createLayout(
   accessToken: string,
   data: CreateLayoutRequest,
 ): Promise<ApiLayoutDetail> {
-  const result = await layoutFetch<ApiResponse<ApiLayoutDetail>>(
+  const result = await apiFetch<ApiResponse<ApiLayoutDetail>>(
     '/layouts',
+    { method: 'POST', headers: JSON_HEADERS, body: JSON.stringify(data) },
     accessToken,
-    {
-      method: 'POST',
-      body: JSON.stringify(data),
-    },
   );
   return result.data;
 }
@@ -81,13 +53,10 @@ export async function updateLayout(
   id: number,
   data: CreateLayoutRequest,
 ): Promise<ApiLayoutDetail> {
-  const result = await layoutFetch<ApiResponse<ApiLayoutDetail>>(
+  const result = await apiFetch<ApiResponse<ApiLayoutDetail>>(
     `/layouts/${id}`,
+    { method: 'PUT', headers: JSON_HEADERS, body: JSON.stringify(data) },
     accessToken,
-    {
-      method: 'PUT',
-      body: JSON.stringify(data),
-    },
   );
   return result.data;
 }
@@ -97,13 +66,10 @@ export async function updateLayoutMeta(
   id: number,
   data: UpdateLayoutMetaRequest,
 ): Promise<ApiLayout> {
-  const result = await layoutFetch<ApiResponse<ApiLayout>>(
+  const result = await apiFetch<ApiResponse<ApiLayout>>(
     `/layouts/${id}`,
+    { method: 'PATCH', headers: JSON_HEADERS, body: JSON.stringify(data) },
     accessToken,
-    {
-      method: 'PATCH',
-      body: JSON.stringify(data),
-    },
   );
   return result.data;
 }
@@ -112,10 +78,10 @@ export async function deleteLayoutApi(
   accessToken: string,
   id: number,
 ): Promise<void> {
-  await layoutFetch<void>(
+  await apiFetch<void>(
     `/layouts/${id}`,
+    { method: 'DELETE', headers: JSON_HEADERS },
     accessToken,
-    { method: 'DELETE' },
   );
 }
 
@@ -123,11 +89,10 @@ export async function cloneLayout(
   accessToken: string,
   id: number,
 ): Promise<ApiLayoutDetail> {
-  const result = await layoutFetch<ApiResponse<ApiLayoutDetail>>(
+  const result = await apiFetch<ApiResponse<ApiLayoutDetail>>(
     `/layouts/${id}/clone`,
+    { method: 'POST', headers: JSON_HEADERS },
     accessToken,
-    { method: 'POST' },
   );
   return result.data;
 }
-

--- a/packages/app/src/api/refImages.api.ts
+++ b/packages/app/src/api/refImages.api.ts
@@ -1,38 +1,12 @@
 import type { ApiResponse, ApiRefImage } from '@gridfinity/shared';
-
-const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? 'http://localhost:3001/api/v1';
-
-async function refImageFetch<T>(
-  path: string,
-  accessToken: string,
-  options: RequestInit = {},
-): Promise<T> {
-  const response = await fetch(`${API_BASE_URL}${path}`, {
-    ...options,
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      ...options.headers,
-    },
-  });
-
-  if (!response.ok) {
-    const errorBody = await response.json().catch(() => null);
-    const message = errorBody?.error?.message ?? `Request failed with status ${response.status}`;
-    throw new Error(message);
-  }
-
-  if (response.status === 204) {
-    return undefined as T;
-  }
-
-  return response.json();
-}
+import { apiFetch } from './apiClient';
 
 export async function fetchRefImages(
   accessToken: string,
 ): Promise<ApiRefImage[]> {
-  const result = await refImageFetch<{ data: ApiRefImage[] }>(
+  const result = await apiFetch<{ data: ApiRefImage[] }>(
     '/ref-images',
+    {},
     accessToken,
   );
   return result.data;
@@ -45,13 +19,10 @@ export async function uploadRefImage(
   const formData = new FormData();
   formData.append('image', file);
 
-  const result = await refImageFetch<ApiResponse<ApiRefImage>>(
+  const result = await apiFetch<ApiResponse<ApiRefImage>>(
     '/ref-images',
+    { method: 'POST', body: formData },
     accessToken,
-    {
-      method: 'POST',
-      body: formData,
-    },
   );
   return result.data;
 }
@@ -63,13 +34,10 @@ export async function uploadGlobalRefImage(
   const formData = new FormData();
   formData.append('image', file);
 
-  const result = await refImageFetch<ApiResponse<ApiRefImage>>(
+  const result = await apiFetch<ApiResponse<ApiRefImage>>(
     '/ref-images/global',
+    { method: 'POST', body: formData },
     accessToken,
-    {
-      method: 'POST',
-      body: formData,
-    },
   );
   return result.data;
 }
@@ -79,14 +47,14 @@ export async function renameRefImage(
   id: number,
   name: string,
 ): Promise<ApiRefImage> {
-  const result = await refImageFetch<ApiResponse<ApiRefImage>>(
+  const result = await apiFetch<ApiResponse<ApiRefImage>>(
     `/ref-images/${id}`,
-    accessToken,
     {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name }),
     },
+    accessToken,
   );
   return result.data;
 }
@@ -95,9 +63,9 @@ export async function deleteRefImage(
   accessToken: string,
   id: number,
 ): Promise<void> {
-  await refImageFetch<void>(
+  await apiFetch<void>(
     `/ref-images/${id}`,
-    accessToken,
     { method: 'DELETE' },
+    accessToken,
   );
 }

--- a/packages/app/src/api/shared.api.ts
+++ b/packages/app/src/api/shared.api.ts
@@ -3,49 +3,20 @@ import type {
   ApiSharedProject,
   ApiSharedLayoutView,
 } from '@gridfinity/shared';
+import { apiFetch } from './apiClient';
 
-const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? 'http://localhost:3001/api/v1';
-
-async function shareFetch<T>(
-  path: string,
-  options: RequestInit = {},
-  accessToken?: string,
-): Promise<T> {
-  const headers: Record<string, string> = {
-    'Content-Type': 'application/json',
-    ...options.headers as Record<string, string>,
-  };
-  if (accessToken) {
-    headers.Authorization = `Bearer ${accessToken}`;
-  }
-
-  const response = await fetch(`${API_BASE_URL}${path}`, {
-    ...options,
-    headers,
-  });
-
-  if (!response.ok) {
-    const errorBody = await response.json().catch(() => null);
-    const message = errorBody?.error?.message ?? `Request failed with status ${response.status}`;
-    throw new Error(message);
-  }
-
-  if (response.status === 204) {
-    return undefined as T;
-  }
-
-  return response.json();
-}
+const JSON_HEADERS = { 'Content-Type': 'application/json' };
 
 export async function createShareLink(
   accessToken: string,
   layoutId: number,
   expiresInDays?: number,
 ): Promise<ApiSharedProject> {
-  const result = await shareFetch<ApiResponse<ApiSharedProject>>(
+  const result = await apiFetch<ApiResponse<ApiSharedProject>>(
     `/layouts/${layoutId}/share`,
     {
       method: 'POST',
+      headers: JSON_HEADERS,
       body: JSON.stringify(expiresInDays ? { expiresInDays } : {}),
     },
     accessToken,
@@ -56,8 +27,9 @@ export async function createShareLink(
 export async function getSharedLayout(
   slug: string,
 ): Promise<ApiSharedLayoutView> {
-  const result = await shareFetch<ApiResponse<ApiSharedLayoutView>>(
+  const result = await apiFetch<ApiResponse<ApiSharedLayoutView>>(
     `/shared/${slug}`,
+    { headers: JSON_HEADERS },
   );
   return result.data;
 }
@@ -66,9 +38,9 @@ export async function deleteShareLink(
   accessToken: string,
   shareId: number,
 ): Promise<void> {
-  await shareFetch<void>(
+  await apiFetch<void>(
     `/shared/${shareId}`,
-    { method: 'DELETE' },
+    { method: 'DELETE', headers: JSON_HEADERS },
     accessToken,
   );
 }
@@ -77,9 +49,9 @@ export async function getSharesByLayout(
   accessToken: string,
   layoutId: number,
 ): Promise<ApiSharedProject[]> {
-  const result = await shareFetch<ApiResponse<ApiSharedProject[]>>(
+  const result = await apiFetch<ApiResponse<ApiSharedProject[]>>(
     `/layouts/${layoutId}/shares`,
-    {},
+    { headers: JSON_HEADERS },
     accessToken,
   );
   return result.data;

--- a/packages/app/src/api/userStls.api.ts
+++ b/packages/app/src/api/userStls.api.ts
@@ -2,7 +2,7 @@ import type { ApiUserStl, ApiUserStlAdmin } from '@gridfinity/shared';
 
 const API_BASE = '/api/v1/user-stls';
 
-async function apiFetch(path: string, token: string, init?: RequestInit): Promise<Response> {
+async function userStlFetch(path: string, token: string, init?: RequestInit): Promise<Response> {
   const isMultipart = init?.body instanceof FormData;
   const res = await fetch(path, {
     ...init,
@@ -21,7 +21,7 @@ async function apiFetch(path: string, token: string, init?: RequestInit): Promis
 }
 
 export async function fetchUserStls(token: string): Promise<ApiUserStl[]> {
-  const res = await apiFetch(API_BASE, token);
+  const res = await userStlFetch(API_BASE, token);
   return res.json() as Promise<ApiUserStl[]>;
 }
 
@@ -29,7 +29,7 @@ export async function uploadUserStl(file: File, name: string, token: string): Pr
   const form = new FormData();
   form.append('file', file);
   form.append('name', name);
-  const res = await apiFetch(API_BASE, token, { method: 'POST', body: form });
+  const res = await userStlFetch(API_BASE, token, { method: 'POST', body: form });
   return res.json() as Promise<ApiUserStl>;
 }
 
@@ -38,7 +38,7 @@ export async function updateUserStl(
   data: { name?: string; gridX?: number | null; gridY?: number | null },
   token: string,
 ): Promise<ApiUserStl> {
-  const res = await apiFetch(`${API_BASE}/${id}`, token, {
+  const res = await userStlFetch(`${API_BASE}/${id}`, token, {
     method: 'PUT',
     body: JSON.stringify(data),
   });
@@ -46,17 +46,17 @@ export async function updateUserStl(
 }
 
 export async function deleteUserStl(id: string, token: string): Promise<void> {
-  await apiFetch(`${API_BASE}/${id}`, token, { method: 'DELETE' });
+  await userStlFetch(`${API_BASE}/${id}`, token, { method: 'DELETE' });
 }
 
 export async function reprocessUserStl(id: string, token: string): Promise<void> {
-  await apiFetch(`${API_BASE}/${id}/reprocess`, token, { method: 'POST' });
+  await userStlFetch(`${API_BASE}/${id}/reprocess`, token, { method: 'POST' });
 }
 
 export async function replaceUserStlFile(id: string, file: File, token: string): Promise<ApiUserStl> {
   const form = new FormData();
   form.append('file', file);
-  const res = await apiFetch(`${API_BASE}/${id}/file`, token, { method: 'PUT', body: form });
+  const res = await userStlFetch(`${API_BASE}/${id}/file`, token, { method: 'PUT', body: form });
   return res.json() as Promise<ApiUserStl>;
 }
 
@@ -65,10 +65,10 @@ export function getUserStlImageUrl(id: string, filename: string): string {
 }
 
 export async function fetchAdminUserStls(token: string): Promise<ApiUserStlAdmin[]> {
-  const res = await apiFetch('/api/v1/admin/user-stls', token);
+  const res = await userStlFetch('/api/v1/admin/user-stls', token);
   return res.json() as Promise<ApiUserStlAdmin[]>;
 }
 
 export async function promoteUserStl(id: string, token: string): Promise<void> {
-  await apiFetch(`/api/v1/admin/user-stls/${id}/promote`, token, { method: 'POST' });
+  await userStlFetch(`/api/v1/admin/user-stls/${id}/promote`, token, { method: 'POST' });
 }

--- a/packages/app/src/components/BinCustomizationPanel.test.tsx
+++ b/packages/app/src/components/BinCustomizationPanel.test.tsx
@@ -757,7 +757,7 @@ describe('BinCustomizationPanel', () => {
           onChange={mockOnChange}
           onReset={mockOnReset}
           customizableFields={['height']}
-          customizationDefaults={{ height: 4 }}
+          parameters={{ height: 4 }}
         />
       );
       fireEvent.click(screen.getByRole('button', { name: /reset/i }));

--- a/packages/app/src/components/BinCustomizationPanel.test.tsx
+++ b/packages/app/src/components/BinCustomizationPanel.test.tsx
@@ -1,11 +1,22 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import { BinCustomizationPanel } from './BinCustomizationPanel';
-import type { BinCustomization, CustomizableField } from '../types/gridfinity';
+import type { BinCustomization, CustomizableFieldDef } from '../types/gridfinity';
 import { DEFAULT_BIN_CUSTOMIZATION } from '../types/gridfinity';
 
-const ALL_FIELDS: CustomizableField[] = ['wallPattern', 'lipStyle', 'fingerSlide', 'wallCutout', 'height'];
-const SHADOWBOX_FIELDS: CustomizableField[] = ['lipStyle', 'fingerSlide', 'wallCutout', 'height'];
+const ALL_FIELDS: CustomizableFieldDef[] = [
+  { field: 'wallPattern', label: 'Wall Pattern', options: ['none', 'grid', 'hexgrid', 'brick'] },
+  { field: 'lipStyle',    label: 'Lip Style',    options: ['normal', 'reduced', 'minimum', 'none'] },
+  { field: 'fingerSlide', label: 'Finger Slide', options: ['none', 'rounded', 'chamfered'] },
+  { field: 'wallCutout',  label: 'Wall Cutout',  options: ['none', 'vertical', 'horizontal', 'both'] },
+  { field: 'height',      label: 'Height',       min: 1, max: 20 },
+];
+const SHADOWBOX_FIELDS: CustomizableFieldDef[] = [
+  { field: 'lipStyle',    label: 'Lip Style',    options: ['normal', 'reduced', 'minimum', 'none'] },
+  { field: 'fingerSlide', label: 'Finger Slide', options: ['none', 'rounded', 'chamfered'] },
+  { field: 'wallCutout',  label: 'Wall Cutout',  options: ['none', 'vertical', 'horizontal', 'both'] },
+  { field: 'height',      label: 'Height',       min: 1, max: 20 },
+];
 
 describe('BinCustomizationPanel', () => {
   const mockOnChange = vi.fn();
@@ -259,10 +270,10 @@ describe('BinCustomizationPanel', () => {
       );
 
       const wallPatternSelect = screen.getByLabelText(/wall pattern/i);
-      fireEvent.change(wallPatternSelect, { target: { value: 'voronoi' } });
+      fireEvent.change(wallPatternSelect, { target: { value: 'brick' } });
 
       expect(mockOnChange).toHaveBeenCalledWith({
-        wallPattern: 'voronoi',
+        wallPattern: 'brick',
         lipStyle: 'reduced',
         fingerSlide: 'rounded',
         wallCutout: 'vertical',
@@ -437,7 +448,7 @@ describe('BinCustomizationPanel', () => {
   });
 
   describe('Wall pattern select options', () => {
-    it('should have all 6 wall pattern options (none, grid, hexgrid, voronoi, voronoigrid, voronoihexgrid)', () => {
+    it('should have all 4 wall pattern options (none, grid, hexgrid, brick)', () => {
       render(
         <BinCustomizationPanel
           customization={DEFAULT_BIN_CUSTOMIZATION}
@@ -455,12 +466,10 @@ describe('BinCustomizationPanel', () => {
       expect(options).toContain('none');
       expect(options).toContain('grid');
       expect(options).toContain('hexgrid');
-      expect(options).toContain('voronoi');
-      expect(options).toContain('voronoigrid');
-      expect(options).toContain('voronoihexgrid');
+      expect(options).toContain('brick');
     });
 
-    it('should have exactly 6 wall pattern options', () => {
+    it('should have exactly 4 wall pattern options', () => {
       render(
         <BinCustomizationPanel
           customization={DEFAULT_BIN_CUSTOMIZATION}
@@ -473,7 +482,7 @@ describe('BinCustomizationPanel', () => {
       const wallPatternSelect = screen.getByLabelText(/wall pattern/i);
       const options = (wallPatternSelect as HTMLSelectElement).options;
 
-      expect(options).toHaveLength(6);
+      expect(options).toHaveLength(4);
     });
   });
 
@@ -668,7 +677,7 @@ describe('BinCustomizationPanel', () => {
           customization={DEFAULT_BIN_CUSTOMIZATION}
           onChange={mockOnChange}
           onReset={mockOnReset}
-          customizableFields={['height']}
+          customizableFields={[{ field: 'height', label: 'Height', min: 1, max: 20 }]}
         />
       );
       expect(screen.getByLabelText('Height in units')).toBeInTheDocument();
@@ -681,7 +690,7 @@ describe('BinCustomizationPanel', () => {
           customization={{ ...DEFAULT_BIN_CUSTOMIZATION, height: 3 }}
           onChange={mockOnChange}
           onReset={mockOnReset}
-          customizableFields={['height']}
+          customizableFields={[{ field: 'height', label: 'Height', min: 1, max: 20 }]}
         />
       );
       expect(screen.getByLabelText('Height in units')).toHaveValue(3);
@@ -694,7 +703,7 @@ describe('BinCustomizationPanel', () => {
           customization={DEFAULT_BIN_CUSTOMIZATION}
           onChange={mockOnChange}
           onReset={mockOnReset}
-          customizableFields={['height']}
+          customizableFields={[{ field: 'height', label: 'Height', min: 1, max: 20 }]}
         />
       );
       fireEvent.change(screen.getByLabelText('Height in units'), { target: { value: '5' } });
@@ -707,7 +716,7 @@ describe('BinCustomizationPanel', () => {
           customization={DEFAULT_BIN_CUSTOMIZATION}
           onChange={mockOnChange}
           onReset={mockOnReset}
-          customizableFields={['height']}
+          customizableFields={[{ field: 'height', label: 'Height', min: 1, max: 20 }]}
         />
       );
       fireEvent.change(screen.getByLabelText('Height in millimeters'), { target: { value: '35' } });
@@ -721,7 +730,7 @@ describe('BinCustomizationPanel', () => {
           customization={DEFAULT_BIN_CUSTOMIZATION}
           onChange={mockOnChange}
           onReset={mockOnReset}
-          customizableFields={['height']}
+          customizableFields={[{ field: 'height', label: 'Height', min: 1, max: 20 }]}
         />
       );
       fireEvent.change(screen.getByLabelText('Height in millimeters'), { target: { value: '23' } });
@@ -737,7 +746,7 @@ describe('BinCustomizationPanel', () => {
           customization={DEFAULT_BIN_CUSTOMIZATION}
           onChange={mockOnChange}
           onReset={mockOnReset}
-          customizableFields={['height']}
+          customizableFields={[{ field: 'height', label: 'Height', min: 1, max: 20 }]}
         />
       );
       fireEvent.change(screen.getByLabelText('Height in millimeters'), { target: { value: '23' } });
@@ -756,7 +765,7 @@ describe('BinCustomizationPanel', () => {
           customization={{ ...DEFAULT_BIN_CUSTOMIZATION, height: 6 }}
           onChange={mockOnChange}
           onReset={mockOnReset}
-          customizableFields={['height']}
+          customizableFields={[{ field: 'height', label: 'Height', min: 1, max: 20 }]}
           parameters={{ height: 4 }}
         />
       );

--- a/packages/app/src/components/BinCustomizationPanel.tsx
+++ b/packages/app/src/components/BinCustomizationPanel.tsx
@@ -5,6 +5,7 @@ import {
 import type {
   BinCustomization,
   CustomizableField,
+  CustomizableFieldDef,
   FingerSlide,
   GeneratorParams,
   LipStyle,
@@ -17,11 +18,13 @@ const MM_PER_HEIGHT_UNIT = 7;
 
 interface HeightFieldProps {
   height: number;
+  min: number;
+  max: number;
   idPrefix: string;
   onChange: (height: number) => void;
 }
 
-function HeightField({ height, idPrefix, onChange }: HeightFieldProps) {
+function HeightField({ height, min, max, idPrefix, onChange }: HeightFieldProps) {
   const [mmEditValue, setMmEditValue] = useState<string | null>(null);
   const [correctionMsg, setCorrectionMsg] = useState<string | null>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -36,7 +39,7 @@ function HeightField({ height, idPrefix, onChange }: HeightFieldProps) {
 
   const handleUnitChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const v = parseInt(e.target.value, 10);
-    if (!isNaN(v) && v >= 1 && v <= 20) {
+    if (!isNaN(v) && v >= min && v <= max) {
       onChange(v);
     }
   };
@@ -56,7 +59,7 @@ function HeightField({ height, idPrefix, onChange }: HeightFieldProps) {
       setCorrectionMsg(`Rounded to ${units}u (${snapped}mm)`);
       timerRef.current = setTimeout(() => setCorrectionMsg(null), 2000);
     }
-    if (units >= 1 && units <= 20) {
+    if (units >= min && units <= max) {
       onChange(units);
     }
   };
@@ -69,8 +72,8 @@ function HeightField({ height, idPrefix, onChange }: HeightFieldProps) {
           id={`${idPrefix}height-units-input`}
           aria-label="Height in units"
           type="number"
-          min={1}
-          max={20}
+          min={min}
+          max={max}
           value={height}
           onChange={handleUnitChange}
         />
@@ -97,17 +100,10 @@ interface BinCustomizationPanelProps {
   customization: BinCustomization | undefined;
   onChange: (customization: BinCustomization) => void;
   onReset: () => void;
-  customizableFields: CustomizableField[];
+  customizableFields: CustomizableFieldDef[];
   parameters?: GeneratorParams;
   idPrefix?: string;
 }
-
-const WALL_PATTERN_OPTIONS: WallPattern[] = [
-  'none', 'grid', 'hexgrid', 'voronoi', 'voronoigrid', 'voronoihexgrid',
-];
-const LIP_STYLE_OPTIONS: LipStyle[] = ['normal', 'reduced', 'minimum', 'none'];
-const FINGER_SLIDE_OPTIONS: FingerSlide[] = ['none', 'rounded', 'chamfered'];
-const WALL_CUTOUT_OPTIONS: WallCutout[] = ['none', 'vertical', 'horizontal', 'both'];
 
 export function BinCustomizationPanel({
   customization,
@@ -131,7 +127,16 @@ export function BinCustomizationPanel({
     current.wallCutout === effectiveDefaults.wallCutout &&
     current.height === effectiveDefaults.height;
 
-  const has = (f: CustomizableField) => customizableFields.includes(f);
+  const fieldDef = (name: CustomizableField) => customizableFields.find(d => d.field === name);
+  const has = (name: CustomizableField) => fieldDef(name) !== undefined;
+  const optionsFor = (name: CustomizableField): string[] => {
+    const def = fieldDef(name);
+    return def && 'options' in def ? def.options : [];
+  };
+
+  const heightDef = fieldDef('height');
+  const heightMin = heightDef && 'min' in heightDef ? heightDef.min : 1;
+  const heightMax = heightDef && 'max' in heightDef ? heightDef.max : 20;
 
   return (
     <div className="bin-customization-panel">
@@ -143,7 +148,7 @@ export function BinCustomizationPanel({
             value={current.wallPattern}
             onChange={(e) => onChange({ ...current, wallPattern: e.target.value as WallPattern })}
           >
-            {WALL_PATTERN_OPTIONS.map((o) => <option key={o} value={o}>{o}</option>)}
+            {optionsFor('wallPattern').map((o) => <option key={o} value={o}>{o}</option>)}
           </select>
         </div>
       )}
@@ -156,7 +161,7 @@ export function BinCustomizationPanel({
             value={current.lipStyle}
             onChange={(e) => onChange({ ...current, lipStyle: e.target.value as LipStyle })}
           >
-            {LIP_STYLE_OPTIONS.map((o) => <option key={o} value={o}>{o}</option>)}
+            {optionsFor('lipStyle').map((o) => <option key={o} value={o}>{o}</option>)}
           </select>
         </div>
       )}
@@ -169,7 +174,7 @@ export function BinCustomizationPanel({
             value={current.fingerSlide}
             onChange={(e) => onChange({ ...current, fingerSlide: e.target.value as FingerSlide })}
           >
-            {FINGER_SLIDE_OPTIONS.map((o) => <option key={o} value={o}>{o}</option>)}
+            {optionsFor('fingerSlide').map((o) => <option key={o} value={o}>{o}</option>)}
           </select>
         </div>
       )}
@@ -182,7 +187,7 @@ export function BinCustomizationPanel({
             value={current.wallCutout}
             onChange={(e) => onChange({ ...current, wallCutout: e.target.value as WallCutout })}
           >
-            {WALL_CUTOUT_OPTIONS.map((o) => <option key={o} value={o}>{o}</option>)}
+            {optionsFor('wallCutout').map((o) => <option key={o} value={o}>{o}</option>)}
           </select>
         </div>
       )}
@@ -190,6 +195,8 @@ export function BinCustomizationPanel({
       {has('height') && (
         <HeightField
           height={current.height}
+          min={heightMin}
+          max={heightMax}
           idPrefix={idPrefix}
           onChange={(h) => onChange({ ...current, height: h })}
         />

--- a/packages/app/src/components/BinCustomizationPanel.tsx
+++ b/packages/app/src/components/BinCustomizationPanel.tsx
@@ -98,7 +98,7 @@ interface BinCustomizationPanelProps {
   onChange: (customization: BinCustomization) => void;
   onReset: () => void;
   customizableFields: CustomizableField[];
-  gridfinityExtendedParams?: GeneratorParams;
+  parameters?: GeneratorParams;
   idPrefix?: string;
 }
 
@@ -114,13 +114,13 @@ export function BinCustomizationPanel({
   onChange,
   onReset,
   customizableFields,
-  gridfinityExtendedParams,
+  parameters,
   idPrefix = '',
 }: BinCustomizationPanelProps) {
   if (customizableFields.length === 0) return null;
 
-  const libraryDefaults = gridfinityExtendedParams
-    ? generatorParamsToBinCustomization(gridfinityExtendedParams, customizableFields)
+  const libraryDefaults = parameters
+    ? generatorParamsToBinCustomization(parameters, customizableFields)
     : {};
   const effectiveDefaults = { ...DEFAULT_BIN_CUSTOMIZATION, ...libraryDefaults };
   const current: BinCustomization = customization ?? effectiveDefaults;

--- a/packages/app/src/components/LibraryManager.test.tsx
+++ b/packages/app/src/components/LibraryManager.test.tsx
@@ -1,0 +1,539 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { LibraryManager } from './LibraryManager';
+import type { LibraryItem, Category } from '../types/gridfinity';
+
+// Mock CategoryManager so we don't need to render the full sub-component
+vi.mock('./CategoryManager', () => ({
+  CategoryManager: ({ onClose }: { onClose: () => void }) => (
+    <div data-testid="category-manager">
+      <button onClick={onClose}>Close Category Manager</button>
+    </div>
+  ),
+}));
+
+const defaultCategories: Category[] = [
+  { id: 'bin', name: 'Bin', color: '#3B82F6' },
+  { id: 'utensil', name: 'Utensil', color: '#10B981' },
+];
+
+const defaultItems: LibraryItem[] = [
+  {
+    id: 'bin-1x1',
+    libraryId: 'default',
+    name: '1x1 Bin',
+    widthUnits: 1,
+    heightUnits: 1,
+    color: '#3B82F6',
+    categories: ['bin'],
+    imageUrl: '/images/bin-1x1.png',
+  },
+  {
+    id: 'bin-2x2',
+    libraryId: 'default',
+    name: '2x2 Bin',
+    widthUnits: 2,
+    heightUnits: 2,
+    color: '#3B82F6',
+    categories: ['bin'],
+  },
+];
+
+function buildProps(overrides: Partial<Parameters<typeof LibraryManager>[0]> = {}) {
+  return {
+    items: defaultItems,
+    categories: defaultCategories,
+    onClose: vi.fn(),
+    onAddItem: vi.fn(),
+    onUpdateItem: vi.fn(),
+    onDeleteItem: vi.fn(),
+    onResetToDefaults: vi.fn(),
+    onAddCategory: vi.fn(),
+    onUpdateCategory: vi.fn(),
+    onDeleteCategory: vi.fn(),
+    onResetCategories: vi.fn(),
+    onUpdateItemCategories: vi.fn(),
+    getCategoryById: (id: string) => defaultCategories.find(c => c.id === id),
+    ...overrides,
+  };
+}
+
+describe('LibraryManager', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------
+  // Rendering / initial state
+  // -------------------------------------------------------------------
+  describe('Initial rendering', () => {
+    it('renders the dialog with aria-label "Manage Library"', () => {
+      render(<LibraryManager {...buildProps()} />);
+      expect(screen.getByRole('dialog', { name: 'Manage Library' })).toBeInTheDocument();
+    });
+
+    it('renders the "Manage Library" heading', () => {
+      render(<LibraryManager {...buildProps()} />);
+      expect(screen.getByRole('heading', { name: /manage library/i })).toBeInTheDocument();
+    });
+
+    it('renders the close button', () => {
+      render(<LibraryManager {...buildProps()} />);
+      expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument();
+    });
+
+    it('renders the item count in the list heading', () => {
+      render(<LibraryManager {...buildProps()} />);
+      expect(screen.getByText(`Library Items (${defaultItems.length})`)).toBeInTheDocument();
+    });
+
+    it('renders each library item name', () => {
+      render(<LibraryManager {...buildProps()} />);
+      for (const item of defaultItems) {
+        expect(screen.getByText(item.name)).toBeInTheDocument();
+      }
+    });
+
+    it('shows "Has image" text for items with imageUrl', () => {
+      render(<LibraryManager {...buildProps()} />);
+      // bin-1x1 has imageUrl, bin-2x2 does not
+      const metaDivs = screen.getAllByText(/has image/i);
+      expect(metaDivs.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('renders action buttons in the list view', () => {
+      render(<LibraryManager {...buildProps()} />);
+      expect(screen.getByRole('button', { name: /add new item/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /manage categories/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /reset to defaults/i })).toBeInTheDocument();
+    });
+
+    it('renders an Edit and Delete button for each item', () => {
+      render(<LibraryManager {...buildProps()} />);
+      const editBtns = screen.getAllByRole('button', { name: /^edit$/i });
+      const deleteBtns = screen.getAllByRole('button', { name: /^delete$/i });
+      expect(editBtns).toHaveLength(defaultItems.length);
+      expect(deleteBtns).toHaveLength(defaultItems.length);
+    });
+
+    it('does not render the form initially', () => {
+      render(<LibraryManager {...buildProps()} />);
+      expect(screen.queryByRole('form')).not.toBeInTheDocument();
+    });
+
+    it('does not render an error message initially', () => {
+      render(<LibraryManager {...buildProps()} />);
+      expect(screen.queryByText(/an error occurred/i)).not.toBeInTheDocument();
+    });
+
+    it('renders with empty items list', () => {
+      render(<LibraryManager {...buildProps({ items: [] })} />);
+      expect(screen.getByText('Library Items (0)')).toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // Closing the dialog
+  // -------------------------------------------------------------------
+  describe('Closing the dialog', () => {
+    it('calls onClose when close button is clicked', () => {
+      const onClose = vi.fn();
+      render(<LibraryManager {...buildProps({ onClose })} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onClose when the overlay backdrop is clicked', () => {
+      const onClose = vi.fn();
+      render(<LibraryManager {...buildProps({ onClose })} />);
+      const overlay = document.querySelector('.library-manager-overlay') as HTMLElement;
+      fireEvent.click(overlay);
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT call onClose when the dialog itself is clicked', () => {
+      const onClose = vi.fn();
+      render(<LibraryManager {...buildProps({ onClose })} />);
+      const dialog = screen.getByRole('dialog', { name: 'Manage Library' });
+      fireEvent.click(dialog);
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('calls onClose when Escape key is pressed', () => {
+      const onClose = vi.fn();
+      render(<LibraryManager {...buildProps({ onClose })} />);
+      fireEvent.keyDown(document, { key: 'Escape' });
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // Add item form
+  // -------------------------------------------------------------------
+  describe('Add item form', () => {
+    it('shows the add form when "Add New Item" button is clicked', () => {
+      render(<LibraryManager {...buildProps()} />);
+      fireEvent.click(screen.getByRole('button', { name: /add new item/i }));
+      expect(screen.getByRole('heading', { name: /add new item/i })).toBeInTheDocument();
+    });
+
+    it('renders all required form fields in add mode', () => {
+      render(<LibraryManager {...buildProps()} />);
+      fireEvent.click(screen.getByRole('button', { name: /add new item/i }));
+      expect(screen.getByLabelText(/^id \*/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/^name \*/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/width \(units\)/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/height \(units\)/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/color \*/i)).toBeInTheDocument();
+    });
+
+    it('renders category checkboxes in add mode', () => {
+      render(<LibraryManager {...buildProps()} />);
+      fireEvent.click(screen.getByRole('button', { name: /add new item/i }));
+      for (const cat of defaultCategories) {
+        expect(screen.getByText(cat.name)).toBeInTheDocument();
+      }
+    });
+
+    it('ID field is enabled in add mode', () => {
+      render(<LibraryManager {...buildProps()} />);
+      fireEvent.click(screen.getByRole('button', { name: /add new item/i }));
+      expect(screen.getByLabelText(/^id \*/i)).not.toBeDisabled();
+    });
+
+    it('submit button says "Add Item" in add mode', () => {
+      render(<LibraryManager {...buildProps()} />);
+      fireEvent.click(screen.getByRole('button', { name: /add new item/i }));
+      expect(screen.getByRole('button', { name: /add item/i })).toBeInTheDocument();
+    });
+
+    it('canceling the add form returns to list view', () => {
+      render(<LibraryManager {...buildProps()} />);
+      fireEvent.click(screen.getByRole('button', { name: /add new item/i }));
+      expect(screen.getByRole('heading', { name: /add new item/i })).toBeInTheDocument();
+      fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+      expect(screen.getByText(`Library Items (${defaultItems.length})`)).toBeInTheDocument();
+    });
+
+    it('calls onAddItem with form data on submit', () => {
+      const onAddItem = vi.fn();
+      render(<LibraryManager {...buildProps({ onAddItem })} />);
+      fireEvent.click(screen.getByRole('button', { name: /add new item/i }));
+
+      fireEvent.change(screen.getByLabelText(/^id \*/i), { target: { value: 'new-bin' } });
+      fireEvent.change(screen.getByLabelText(/^name \*/i), { target: { value: 'New Bin' } });
+
+      fireEvent.click(screen.getByRole('button', { name: /add item/i }));
+      expect(onAddItem).toHaveBeenCalledTimes(1);
+      expect(onAddItem).toHaveBeenCalledWith(expect.objectContaining({ id: 'new-bin', name: 'New Bin' }));
+    });
+
+    it('returns to list view after successful add', () => {
+      const onAddItem = vi.fn();
+      render(<LibraryManager {...buildProps({ onAddItem })} />);
+      fireEvent.click(screen.getByRole('button', { name: /add new item/i }));
+      fireEvent.change(screen.getByLabelText(/^id \*/i), { target: { value: 'another-bin' } });
+      fireEvent.change(screen.getByLabelText(/^name \*/i), { target: { value: 'Another Bin' } });
+      fireEvent.click(screen.getByRole('button', { name: /add item/i }));
+      expect(screen.getByText(`Library Items (${defaultItems.length})`)).toBeInTheDocument();
+    });
+
+    it('shows error message when onAddItem throws', () => {
+      const onAddItem = vi.fn().mockImplementation(() => {
+        throw new Error('Duplicate ID');
+      });
+      render(<LibraryManager {...buildProps({ onAddItem })} />);
+      fireEvent.click(screen.getByRole('button', { name: /add new item/i }));
+      fireEvent.change(screen.getByLabelText(/^id \*/i), { target: { value: 'dup' } });
+      fireEvent.change(screen.getByLabelText(/^name \*/i), { target: { value: 'Dup' } });
+      fireEvent.click(screen.getByRole('button', { name: /add item/i }));
+      expect(screen.getByText('Duplicate ID')).toBeInTheDocument();
+    });
+
+    it('shows validation warning when no categories are selected', () => {
+      render(<LibraryManager {...buildProps()} />);
+      fireEvent.click(screen.getByRole('button', { name: /add new item/i }));
+
+      // Uncheck all categories
+      for (const cat of defaultCategories) {
+        const checkbox = screen.getByRole('checkbox', { name: new RegExp(cat.name, 'i') });
+        if ((checkbox as HTMLInputElement).checked) {
+          fireEvent.click(checkbox);
+        }
+      }
+
+      expect(screen.getByText(/at least one category must be selected/i)).toBeInTheDocument();
+    });
+
+    it('toggling category checkbox updates the form state', () => {
+      render(<LibraryManager {...buildProps()} />);
+      fireEvent.click(screen.getByRole('button', { name: /add new item/i }));
+
+      const utensilCheckbox = screen.getByRole('checkbox', { name: /utensil/i });
+      fireEvent.click(utensilCheckbox);
+      expect((utensilCheckbox as HTMLInputElement).checked).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // Edit item form
+  // -------------------------------------------------------------------
+  describe('Edit item form', () => {
+    it('shows the edit form when Edit button is clicked', () => {
+      render(<LibraryManager {...buildProps()} />);
+      const editBtns = screen.getAllByRole('button', { name: /^edit$/i });
+      fireEvent.click(editBtns[0]);
+      expect(screen.getByRole('heading', { name: /edit item/i })).toBeInTheDocument();
+    });
+
+    it('pre-populates form fields with the item data', () => {
+      render(<LibraryManager {...buildProps()} />);
+      const editBtns = screen.getAllByRole('button', { name: /^edit$/i });
+      fireEvent.click(editBtns[0]);
+
+      const idInput = screen.getByLabelText(/^id \*/i) as HTMLInputElement;
+      const nameInput = screen.getByLabelText(/^name \*/i) as HTMLInputElement;
+      expect(idInput.value).toBe(defaultItems[0].id);
+      expect(nameInput.value).toBe(defaultItems[0].name);
+    });
+
+    it('ID field is disabled in edit mode', () => {
+      render(<LibraryManager {...buildProps()} />);
+      const editBtns = screen.getAllByRole('button', { name: /^edit$/i });
+      fireEvent.click(editBtns[0]);
+      expect(screen.getByLabelText(/^id \*/i)).toBeDisabled();
+    });
+
+    it('submit button says "Save Changes" in edit mode', () => {
+      render(<LibraryManager {...buildProps()} />);
+      const editBtns = screen.getAllByRole('button', { name: /^edit$/i });
+      fireEvent.click(editBtns[0]);
+      expect(screen.getByRole('button', { name: /save changes/i })).toBeInTheDocument();
+    });
+
+    it('calls onUpdateItem with the item id and updated data on submit', () => {
+      const onUpdateItem = vi.fn();
+      render(<LibraryManager {...buildProps({ onUpdateItem })} />);
+      const editBtns = screen.getAllByRole('button', { name: /^edit$/i });
+      fireEvent.click(editBtns[0]);
+
+      const nameInput = screen.getByLabelText(/^name \*/i);
+      fireEvent.change(nameInput, { target: { value: 'Updated Name' } });
+
+      fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+      expect(onUpdateItem).toHaveBeenCalledTimes(1);
+      expect(onUpdateItem).toHaveBeenCalledWith(
+        defaultItems[0].id,
+        expect.objectContaining({ name: 'Updated Name' })
+      );
+    });
+
+    it('returns to list view after successful edit', () => {
+      const onUpdateItem = vi.fn();
+      render(<LibraryManager {...buildProps({ onUpdateItem })} />);
+      const editBtns = screen.getAllByRole('button', { name: /^edit$/i });
+      fireEvent.click(editBtns[0]);
+      fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+      expect(screen.getByText(`Library Items (${defaultItems.length})`)).toBeInTheDocument();
+    });
+
+    it('canceling edit form returns to list view', () => {
+      render(<LibraryManager {...buildProps()} />);
+      const editBtns = screen.getAllByRole('button', { name: /^edit$/i });
+      fireEvent.click(editBtns[0]);
+      fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+      expect(screen.getByText(`Library Items (${defaultItems.length})`)).toBeInTheDocument();
+    });
+
+    it('shows error message when onUpdateItem throws', () => {
+      const onUpdateItem = vi.fn().mockImplementation(() => {
+        throw new Error('Update failed');
+      });
+      render(<LibraryManager {...buildProps({ onUpdateItem })} />);
+      const editBtns = screen.getAllByRole('button', { name: /^edit$/i });
+      fireEvent.click(editBtns[0]);
+      fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+      expect(screen.getByText('Update failed')).toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // Delete item
+  // -------------------------------------------------------------------
+  describe('Delete item', () => {
+    it('opens a confirmation dialog when Delete is clicked', async () => {
+      render(<LibraryManager {...buildProps()} />);
+      const deleteBtns = screen.getAllByRole('button', { name: /^delete$/i });
+      fireEvent.click(deleteBtns[0]);
+      await waitFor(() => {
+        expect(screen.getByRole('dialog', { name: /delete item/i })).toBeInTheDocument();
+      });
+    });
+
+    it('calls onDeleteItem when deletion is confirmed', async () => {
+      const onDeleteItem = vi.fn();
+      render(<LibraryManager {...buildProps({ onDeleteItem })} />);
+      const deleteBtns = screen.getAllByRole('button', { name: /^delete$/i });
+      fireEvent.click(deleteBtns[0]);
+
+      // Wait for the confirm dialog to appear then click its confirm button
+      const confirmBtn = await waitFor(() => {
+        const btn = document.querySelector('.confirm-dialog-confirm') as HTMLElement;
+        if (!btn) throw new Error('Confirm button not found');
+        return btn;
+      });
+      fireEvent.click(confirmBtn);
+
+      await waitFor(() => {
+        expect(onDeleteItem).toHaveBeenCalledWith(defaultItems[0].id);
+      });
+    });
+
+    it('does NOT call onDeleteItem when deletion is cancelled', async () => {
+      const onDeleteItem = vi.fn();
+      render(<LibraryManager {...buildProps({ onDeleteItem })} />);
+      const deleteBtns = screen.getAllByRole('button', { name: /^delete$/i });
+      fireEvent.click(deleteBtns[0]);
+
+      const cancelBtn = await waitFor(() => screen.getByRole('button', { name: /cancel/i }));
+      fireEvent.click(cancelBtn);
+
+      expect(onDeleteItem).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // Reset to defaults
+  // -------------------------------------------------------------------
+  describe('Reset to defaults', () => {
+    it('opens a confirmation dialog when Reset to Defaults is clicked', async () => {
+      render(<LibraryManager {...buildProps()} />);
+      fireEvent.click(screen.getByRole('button', { name: /reset to defaults/i }));
+      await waitFor(() => {
+        expect(screen.getByRole('dialog', { name: /reset library/i })).toBeInTheDocument();
+      });
+    });
+
+    it('calls onResetToDefaults when reset is confirmed', async () => {
+      const onResetToDefaults = vi.fn();
+      render(<LibraryManager {...buildProps({ onResetToDefaults })} />);
+      fireEvent.click(screen.getByRole('button', { name: /reset to defaults/i }));
+
+      const resetBtn = await waitFor(() => screen.getByRole('button', { name: /^reset$/i }));
+      fireEvent.click(resetBtn);
+
+      await waitFor(() => {
+        expect(onResetToDefaults).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('does NOT call onResetToDefaults when reset is cancelled', async () => {
+      const onResetToDefaults = vi.fn();
+      render(<LibraryManager {...buildProps({ onResetToDefaults })} />);
+      fireEvent.click(screen.getByRole('button', { name: /reset to defaults/i }));
+
+      const cancelBtn = await waitFor(() => screen.getByRole('button', { name: /cancel/i }));
+      fireEvent.click(cancelBtn);
+
+      expect(onResetToDefaults).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // Category Manager
+  // -------------------------------------------------------------------
+  describe('Category Manager', () => {
+    it('shows the CategoryManager when "Manage Categories" is clicked', () => {
+      render(<LibraryManager {...buildProps()} />);
+      fireEvent.click(screen.getByRole('button', { name: /manage categories/i }));
+      expect(screen.getByTestId('category-manager')).toBeInTheDocument();
+    });
+
+    it('hides the item list when CategoryManager is shown', () => {
+      render(<LibraryManager {...buildProps()} />);
+      fireEvent.click(screen.getByRole('button', { name: /manage categories/i }));
+      expect(screen.queryByText(`Library Items (${defaultItems.length})`)).not.toBeInTheDocument();
+    });
+
+    it('returns to list view when CategoryManager is closed', () => {
+      render(<LibraryManager {...buildProps()} />);
+      fireEvent.click(screen.getByRole('button', { name: /manage categories/i }));
+      fireEvent.click(screen.getByRole('button', { name: /close category manager/i }));
+      expect(screen.getByText(`Library Items (${defaultItems.length})`)).toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // handleCategoryUpdate (cascades item category IDs)
+  // -------------------------------------------------------------------
+  describe('handleCategoryUpdate', () => {
+    it('calls onUpdateItemCategories when a category id changes', () => {
+      const onUpdateItemCategories = vi.fn();
+      const onUpdateCategory = vi.fn();
+      const getCategoryById = (id: string) => defaultCategories.find(c => c.id === id);
+
+      render(
+        <LibraryManager
+          {...buildProps({ onUpdateItemCategories, onUpdateCategory, getCategoryById })}
+        />
+      );
+
+      // CategoryManager is mocked — we need to trigger handleCategoryUpdate indirectly.
+      // The only way to reach it is by navigating to the form; however, handleCategoryUpdate
+      // is passed to CategoryManager. Since CategoryManager is mocked, we verify the prop
+      // is correctly threaded by checking the mock CategoryManager rendered when categories
+      // panel is opened.
+      fireEvent.click(screen.getByRole('button', { name: /manage categories/i }));
+      expect(screen.getByTestId('category-manager')).toBeInTheDocument();
+      // Prop threading verified by the CategoryManager mock rendering successfully.
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // Item details displayed in list
+  // -------------------------------------------------------------------
+  describe('Item details in list', () => {
+    it('displays item dimensions', () => {
+      render(<LibraryManager {...buildProps()} />);
+      // bin-1x1 => "1×1 units"
+      expect(screen.getByText(/1×1 units/)).toBeInTheDocument();
+    });
+
+    it('displays item ID', () => {
+      render(<LibraryManager {...buildProps()} />);
+      expect(screen.getByText(`ID: ${defaultItems[0].id}`)).toBeInTheDocument();
+    });
+
+    it('displays item categories', () => {
+      render(<LibraryManager {...buildProps()} />);
+      // The meta row contains "bin" for category
+      const metas = document.querySelectorAll('.item-meta');
+      expect(metas.length).toBeGreaterThanOrEqual(1);
+      expect(metas[0].textContent).toContain('bin');
+    });
+
+    it('renders color box with item color as background', () => {
+      render(<LibraryManager {...buildProps()} />);
+      const colorBoxes = document.querySelectorAll('.item-color-box');
+      expect(colorBoxes.length).toBe(defaultItems.length);
+      expect((colorBoxes[0] as HTMLElement).style.backgroundColor).toBeTruthy();
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // Accessibility
+  // -------------------------------------------------------------------
+  describe('Accessibility', () => {
+    it('dialog has aria-modal="true"', () => {
+      render(<LibraryManager {...buildProps()} />);
+      const dialog = screen.getByRole('dialog', { name: 'Manage Library' });
+      expect(dialog).toHaveAttribute('aria-modal', 'true');
+    });
+
+    it('dialog has a tabIndex so it can receive focus', () => {
+      render(<LibraryManager {...buildProps()} />);
+      const dialog = screen.getByRole('dialog', { name: 'Manage Library' });
+      expect(dialog).toHaveAttribute('tabindex', '-1');
+    });
+  });
+});

--- a/packages/app/src/components/LibraryManager.test.tsx
+++ b/packages/app/src/components/LibraryManager.test.tsx
@@ -3,15 +3,6 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { LibraryManager } from './LibraryManager';
 import type { LibraryItem, Category } from '../types/gridfinity';
 
-// Mock CategoryManager so we don't need to render the full sub-component
-vi.mock('./CategoryManager', () => ({
-  CategoryManager: ({ onClose }: { onClose: () => void }) => (
-    <div data-testid="category-manager">
-      <button onClick={onClose}>Close Category Manager</button>
-    </div>
-  ),
-}));
-
 const defaultCategories: Category[] = [
   { id: 'bin', name: 'Bin', color: '#3B82F6' },
   { id: 'utensil', name: 'Utensil', color: '#10B981' },
@@ -446,7 +437,7 @@ describe('LibraryManager', () => {
     it('shows the CategoryManager when "Manage Categories" is clicked', () => {
       render(<LibraryManager {...buildProps()} />);
       fireEvent.click(screen.getByRole('button', { name: /manage categories/i }));
-      expect(screen.getByTestId('category-manager')).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: /manage categories/i })).toBeInTheDocument();
     });
 
     it('hides the item list when CategoryManager is shown', () => {
@@ -458,34 +449,18 @@ describe('LibraryManager', () => {
     it('returns to list view when CategoryManager is closed', () => {
       render(<LibraryManager {...buildProps()} />);
       fireEvent.click(screen.getByRole('button', { name: /manage categories/i }));
-      fireEvent.click(screen.getByRole('button', { name: /close category manager/i }));
+      // CategoryManager renders its own close button; click the one inside the
+      // Manage Categories panel (the heading distinguishes it from LibraryManager's own close)
+      expect(screen.getByRole('heading', { name: /manage categories/i })).toBeInTheDocument();
+      const closeButtons = screen.getAllByRole('button', { name: /^close$/i });
+      fireEvent.click(closeButtons[closeButtons.length - 1]);
       expect(screen.getByText(`Library Items (${defaultItems.length})`)).toBeInTheDocument();
     });
-  });
 
-  // -------------------------------------------------------------------
-  // handleCategoryUpdate (cascades item category IDs)
-  // -------------------------------------------------------------------
-  describe('handleCategoryUpdate', () => {
-    it('calls onUpdateItemCategories when a category id changes', () => {
-      const onUpdateItemCategories = vi.fn();
-      const onUpdateCategory = vi.fn();
-      const getCategoryById = (id: string) => defaultCategories.find(c => c.id === id);
-
-      render(
-        <LibraryManager
-          {...buildProps({ onUpdateItemCategories, onUpdateCategory, getCategoryById })}
-        />
-      );
-
-      // CategoryManager is mocked — we need to trigger handleCategoryUpdate indirectly.
-      // The only way to reach it is by navigating to the form; however, handleCategoryUpdate
-      // is passed to CategoryManager. Since CategoryManager is mocked, we verify the prop
-      // is correctly threaded by checking the mock CategoryManager rendered when categories
-      // panel is opened.
+    it('renders category list inside CategoryManager', () => {
+      render(<LibraryManager {...buildProps()} />);
       fireEvent.click(screen.getByRole('button', { name: /manage categories/i }));
-      expect(screen.getByTestId('category-manager')).toBeInTheDocument();
-      // Prop threading verified by the CategoryManager mock rendering successfully.
+      expect(screen.getByText(`Categories (${defaultCategories.length})`)).toBeInTheDocument();
     });
   });
 

--- a/packages/app/src/components/PlacedItemOverlay.test.tsx
+++ b/packages/app/src/components/PlacedItemOverlay.test.tsx
@@ -42,7 +42,7 @@ describe('PlacedItemOverlay', () => {
 
   const mockGetLibraryMeta = vi.fn().mockResolvedValue({
     customizableFields: ['wallPattern', 'lipStyle', 'fingerSlide', 'wallCutout', 'height'],
-    customizationDefaults: {},
+    parameters: {},
   });
 
   const mockOnSelect = vi.fn();
@@ -1808,7 +1808,7 @@ describe('PlacedItemOverlay', () => {
           getItemById={mockGetItemById}
           onCustomizationChange={vi.fn()}
           onCustomizationReset={vi.fn()}
-          getLibraryMeta={async () => ({ customizableFields: ['lipStyle'], customizationDefaults: {} })}
+          getLibraryMeta={async () => ({ customizableFields: ['lipStyle'], parameters: {} })}
         />
       );
       // Wait for libraryMeta to load so the gear button is rendered and ref is attached
@@ -1986,7 +1986,7 @@ describe('PlacedItemOverlay', () => {
           onSelect={vi.fn()}
           getItemById={mockGetItemById}
           onCustomizationChange={vi.fn()}
-          getLibraryMeta={async () => ({ customizableFields: ['lipStyle'], customizationDefaults: {} })}
+          getLibraryMeta={async () => ({ customizableFields: ['lipStyle'], parameters: {} })}
         />
       );
 
@@ -2007,7 +2007,7 @@ describe('PlacedItemOverlay', () => {
           onSelect={vi.fn()}
           getItemById={mockGetItemById}
           onCustomizationChange={vi.fn()}
-          getLibraryMeta={async () => ({ customizableFields: ['lipStyle'], customizationDefaults: {} })}
+          getLibraryMeta={async () => ({ customizableFields: ['lipStyle'], parameters: {} })}
         />
       );
 
@@ -2034,7 +2034,7 @@ describe('PlacedItemOverlay', () => {
           onSelect={vi.fn()}
           getItemById={mockGetItemById}
           onCustomizationChange={vi.fn()}
-          getLibraryMeta={async () => ({ customizableFields: ['lipStyle'], customizationDefaults: {} })}
+          getLibraryMeta={async () => ({ customizableFields: ['lipStyle'], parameters: {} })}
         />
       );
 
@@ -2260,7 +2260,7 @@ describe('PlacedItemOverlay', () => {
           onSelect={vi.fn()}
           getItemById={mockGetItemById}
           onCustomizationChange={vi.fn()}
-          getLibraryMeta={async () => ({ customizableFields: ['lipStyle'], customizationDefaults: {} })}
+          getLibraryMeta={async () => ({ customizableFields: ['lipStyle'], parameters: {} })}
         />
       );
 
@@ -2288,7 +2288,7 @@ describe('PlacedItemOverlay', () => {
           onSelect={vi.fn()}
           getItemById={mockGetItemById}
           onCustomizationChange={vi.fn()}
-          getLibraryMeta={async () => ({ customizableFields: ['lipStyle'], customizationDefaults: {} })}
+          getLibraryMeta={async () => ({ customizableFields: ['lipStyle'], parameters: {} })}
         />
       );
 
@@ -2316,7 +2316,7 @@ describe('PlacedItemOverlay', () => {
           onSelect={vi.fn()}
           getItemById={mockGetItemById}
           onCustomizationChange={vi.fn()}
-          getLibraryMeta={async () => ({ customizableFields: ['lipStyle'], customizationDefaults: {} })}
+          getLibraryMeta={async () => ({ customizableFields: ['lipStyle'], parameters: {} })}
         />
       );
 
@@ -2347,7 +2347,7 @@ describe('PlacedItemOverlay', () => {
           onSelect={vi.fn()}
           getItemById={mockGetItemById}
           onCustomizationChange={vi.fn()}
-          getLibraryMeta={async () => ({ customizableFields: ['lipStyle'], customizationDefaults: {} })}
+          getLibraryMeta={async () => ({ customizableFields: ['lipStyle'], parameters: {} })}
         />
       );
 
@@ -2378,7 +2378,7 @@ describe('PlacedItemOverlay', () => {
           onSelect={vi.fn()}
           getItemById={mockGetItemById}
           onCustomizationChange={vi.fn()}
-          getLibraryMeta={async () => ({ customizableFields: ['lipStyle'], customizationDefaults: {} })}
+          getLibraryMeta={async () => ({ customizableFields: ['lipStyle'], parameters: {} })}
         />
       );
 
@@ -2415,7 +2415,7 @@ describe('PlacedItemOverlay', () => {
           onSelect={vi.fn()}
           getItemById={mockGetItemById}
           onCustomizationChange={vi.fn()}
-          getLibraryMeta={async () => ({ customizableFields: ['lipStyle'], customizationDefaults: {} })}
+          getLibraryMeta={async () => ({ customizableFields: ['lipStyle'], parameters: {} })}
         />
       );
 

--- a/packages/app/src/components/PlacedItemOverlay.test.tsx
+++ b/packages/app/src/components/PlacedItemOverlay.test.tsx
@@ -41,7 +41,13 @@ describe('PlacedItemOverlay', () => {
   };
 
   const mockGetLibraryMeta = vi.fn().mockResolvedValue({
-    customizableFields: ['wallPattern', 'lipStyle', 'fingerSlide', 'wallCutout', 'height'],
+    customizableFields: [
+      { field: 'wallPattern', label: 'Wall Pattern', options: ['none', 'grid', 'hexgrid', 'brick'] },
+      { field: 'lipStyle',    label: 'Lip Style',    options: ['normal', 'reduced', 'minimum', 'none'] },
+      { field: 'fingerSlide', label: 'Finger Slide', options: ['none', 'rounded', 'chamfered'] },
+      { field: 'wallCutout',  label: 'Wall Cutout',  options: ['none', 'vertical', 'horizontal', 'both'] },
+      { field: 'height',      label: 'Height',       min: 1, max: 20 },
+    ],
     parameters: {},
   });
 
@@ -1808,7 +1814,7 @@ describe('PlacedItemOverlay', () => {
           getItemById={mockGetItemById}
           onCustomizationChange={vi.fn()}
           onCustomizationReset={vi.fn()}
-          getLibraryMeta={async () => ({ customizableFields: ['lipStyle'], parameters: {} })}
+          getLibraryMeta={async () => ({ customizableFields: [{ field: 'lipStyle', label: 'Lip Style', options: ['normal', 'reduced', 'minimum', 'none'] }], parameters: {} })}
         />
       );
       // Wait for libraryMeta to load so the gear button is rendered and ref is attached
@@ -1986,7 +1992,7 @@ describe('PlacedItemOverlay', () => {
           onSelect={vi.fn()}
           getItemById={mockGetItemById}
           onCustomizationChange={vi.fn()}
-          getLibraryMeta={async () => ({ customizableFields: ['lipStyle'], parameters: {} })}
+          getLibraryMeta={async () => ({ customizableFields: [{ field: 'lipStyle', label: 'Lip Style', options: ['normal', 'reduced', 'minimum', 'none'] }], parameters: {} })}
         />
       );
 
@@ -2007,7 +2013,7 @@ describe('PlacedItemOverlay', () => {
           onSelect={vi.fn()}
           getItemById={mockGetItemById}
           onCustomizationChange={vi.fn()}
-          getLibraryMeta={async () => ({ customizableFields: ['lipStyle'], parameters: {} })}
+          getLibraryMeta={async () => ({ customizableFields: [{ field: 'lipStyle', label: 'Lip Style', options: ['normal', 'reduced', 'minimum', 'none'] }], parameters: {} })}
         />
       );
 
@@ -2034,7 +2040,7 @@ describe('PlacedItemOverlay', () => {
           onSelect={vi.fn()}
           getItemById={mockGetItemById}
           onCustomizationChange={vi.fn()}
-          getLibraryMeta={async () => ({ customizableFields: ['lipStyle'], parameters: {} })}
+          getLibraryMeta={async () => ({ customizableFields: [{ field: 'lipStyle', label: 'Lip Style', options: ['normal', 'reduced', 'minimum', 'none'] }], parameters: {} })}
         />
       );
 
@@ -2103,11 +2109,11 @@ describe('PlacedItemOverlay', () => {
       fireEvent.click(customizeBtn);
 
       const wallPatternSelect = screen.getByLabelText('Wall Pattern') as HTMLSelectElement;
-      fireEvent.change(wallPatternSelect, { target: { value: 'voronoi' } });
+      fireEvent.change(wallPatternSelect, { target: { value: 'grid' } });
 
       expect(mockOnCustomizationChange).toHaveBeenCalledWith(
         'custom-item-123',
-        expect.objectContaining({ wallPattern: 'voronoi' })
+        expect.objectContaining({ wallPattern: 'grid' })
       );
     });
 
@@ -2260,7 +2266,7 @@ describe('PlacedItemOverlay', () => {
           onSelect={vi.fn()}
           getItemById={mockGetItemById}
           onCustomizationChange={vi.fn()}
-          getLibraryMeta={async () => ({ customizableFields: ['lipStyle'], parameters: {} })}
+          getLibraryMeta={async () => ({ customizableFields: [{ field: 'lipStyle', label: 'Lip Style', options: ['normal', 'reduced', 'minimum', 'none'] }], parameters: {} })}
         />
       );
 
@@ -2288,7 +2294,7 @@ describe('PlacedItemOverlay', () => {
           onSelect={vi.fn()}
           getItemById={mockGetItemById}
           onCustomizationChange={vi.fn()}
-          getLibraryMeta={async () => ({ customizableFields: ['lipStyle'], parameters: {} })}
+          getLibraryMeta={async () => ({ customizableFields: [{ field: 'lipStyle', label: 'Lip Style', options: ['normal', 'reduced', 'minimum', 'none'] }], parameters: {} })}
         />
       );
 
@@ -2316,7 +2322,7 @@ describe('PlacedItemOverlay', () => {
           onSelect={vi.fn()}
           getItemById={mockGetItemById}
           onCustomizationChange={vi.fn()}
-          getLibraryMeta={async () => ({ customizableFields: ['lipStyle'], parameters: {} })}
+          getLibraryMeta={async () => ({ customizableFields: [{ field: 'lipStyle', label: 'Lip Style', options: ['normal', 'reduced', 'minimum', 'none'] }], parameters: {} })}
         />
       );
 
@@ -2347,7 +2353,7 @@ describe('PlacedItemOverlay', () => {
           onSelect={vi.fn()}
           getItemById={mockGetItemById}
           onCustomizationChange={vi.fn()}
-          getLibraryMeta={async () => ({ customizableFields: ['lipStyle'], parameters: {} })}
+          getLibraryMeta={async () => ({ customizableFields: [{ field: 'lipStyle', label: 'Lip Style', options: ['normal', 'reduced', 'minimum', 'none'] }], parameters: {} })}
         />
       );
 
@@ -2378,7 +2384,7 @@ describe('PlacedItemOverlay', () => {
           onSelect={vi.fn()}
           getItemById={mockGetItemById}
           onCustomizationChange={vi.fn()}
-          getLibraryMeta={async () => ({ customizableFields: ['lipStyle'], parameters: {} })}
+          getLibraryMeta={async () => ({ customizableFields: [{ field: 'lipStyle', label: 'Lip Style', options: ['normal', 'reduced', 'minimum', 'none'] }], parameters: {} })}
         />
       );
 
@@ -2415,7 +2421,7 @@ describe('PlacedItemOverlay', () => {
           onSelect={vi.fn()}
           getItemById={mockGetItemById}
           onCustomizationChange={vi.fn()}
-          getLibraryMeta={async () => ({ customizableFields: ['lipStyle'], parameters: {} })}
+          getLibraryMeta={async () => ({ customizableFields: [{ field: 'lipStyle', label: 'Lip Style', options: ['normal', 'reduced', 'minimum', 'none'] }], parameters: {} })}
         />
       );
 

--- a/packages/app/src/components/PlacedItemOverlay.tsx
+++ b/packages/app/src/components/PlacedItemOverlay.tsx
@@ -46,7 +46,7 @@ export const PlacedItemOverlay = memo(function PlacedItemOverlay({ item, gridX, 
   const [popoverPos, setPopoverPos] = useState<PopoverPos | null>(null);
   const gearButtonRef = useRef<HTMLButtonElement>(null);
   const [contextMenuPos, setContextMenuPos] = useState<{ x: number; y: number } | null>(null);
-  const [libraryMeta, setLibraryMeta] = useState<LibraryMeta>({ customizableFields: [], gridfinityExtendedParams: {} });
+  const [libraryMeta, setLibraryMeta] = useState<LibraryMeta>({ customizableFields: [], parameters: {} });
 
   useEffect(() => {
     if (!getLibraryMeta) return;
@@ -90,10 +90,18 @@ export const PlacedItemOverlay = memo(function PlacedItemOverlay({ item, gridX, 
   const orthoUrl = libraryItem?.imageUrl;
   const usingPerspective = imageViewMode === 'perspective' && !!perspectiveUrl;
 
+  // Use explicit rotation-specific URLs when available, fall back to derived
+  const getPerspectiveUrlForRotation = (rotation: typeof item.rotation): string | undefined => {
+    if (!perspectiveUrl) return undefined;
+    if (rotation === 90) return libraryItem?.perspectiveImageUrl90 ?? getRotatedPerspectiveUrl(perspectiveUrl, 90);
+    if (rotation === 180) return libraryItem?.perspectiveImageUrl180 ?? getRotatedPerspectiveUrl(perspectiveUrl, 180);
+    if (rotation === 270) return libraryItem?.perspectiveImageUrl270 ?? getRotatedPerspectiveUrl(perspectiveUrl, 270);
+    return perspectiveUrl; // 0°
+  };
+
   const imageSrc = (() => {
     if (imageViewMode === 'perspective' && perspectiveUrl) {
-      if (item.rotation === 0) return perspectiveUrl;
-      return getRotatedPerspectiveUrl(perspectiveUrl, item.rotation);
+      return getPerspectiveUrlForRotation(item.rotation);
     }
     return imageViewMode === 'perspective' ? (perspectiveUrl || orthoUrl) : orthoUrl;
   })();
@@ -170,8 +178,8 @@ export const PlacedItemOverlay = memo(function PlacedItemOverlay({ item, gridX, 
 
   const handlePopoverReset = useCallback(() => {
     const allFields = ['wallPattern', 'lipStyle', 'fingerSlide', 'wallCutout', 'height'] as const;
-    const libraryDefaults = item.gridfinityExtendedParams
-      ? generatorParamsToBinCustomization(item.gridfinityExtendedParams, [...allFields])
+    const libraryDefaults = item.parameters
+      ? generatorParamsToBinCustomization(item.parameters, [...allFields])
       : {};
     const hasLibraryDefaults = Object.keys(libraryDefaults).length > 0;
     if (hasLibraryDefaults) {
@@ -355,7 +363,7 @@ export const PlacedItemOverlay = memo(function PlacedItemOverlay({ item, gridX, 
             onReset={handlePopoverReset}
             idPrefix="inline-"
             customizableFields={libraryMeta.customizableFields}
-            gridfinityExtendedParams={item.gridfinityExtendedParams}
+            parameters={item.parameters}
           />
         </div>,
         document.body

--- a/packages/app/src/contexts/GridDimensionsContext.tsx
+++ b/packages/app/src/contexts/GridDimensionsContext.tsx
@@ -1,0 +1,47 @@
+/**
+ * GridDimensionsContext
+ *
+ * Focused context for drawer dimensions, unit system, and derived grid values.
+ * Consumers that only need grid/dimension data should prefer `useGridDimensions`
+ * over the broader `useWorkspace` hook.
+ *
+ * This context is backed by `WorkspaceContext` — it is not a separate provider.
+ * It re-reads the same underlying context and exposes a narrowed slice.
+ */
+import { createContext, useContext } from 'react';
+import type { UnitSystem, ImperialFormat, GridSpacerConfig, GridResult, ComputedSpacer } from '../types/gridfinity';
+
+export interface GridDimensionsContextValue {
+  // Drawer dimensions (in current unit system)
+  width: number;
+  setWidth: (w: number) => void;
+  depth: number;
+  setDepth: (d: number) => void;
+
+  // Unit system
+  unitSystem: UnitSystem;
+  setUnitSystem: (u: UnitSystem) => void;
+  imperialFormat: ImperialFormat;
+  setImperialFormat: (f: ImperialFormat) => void;
+
+  // Spacer configuration
+  spacerConfig: GridSpacerConfig;
+  setSpacerConfig: (c: GridSpacerConfig) => void;
+
+  // Handles unit conversion on change
+  handleUnitChange: (newUnit: UnitSystem) => void;
+
+  // Derived grid results
+  gridResult: GridResult;
+  drawerWidth: number;
+  drawerDepth: number;
+  spacers: ComputedSpacer[];
+}
+
+export const GridDimensionsContext = createContext<GridDimensionsContextValue | null>(null);
+
+export function useGridDimensions(): GridDimensionsContextValue {
+  const ctx = useContext(GridDimensionsContext);
+  if (!ctx) throw new Error('useGridDimensions must be used within WorkspaceProvider');
+  return ctx;
+}

--- a/packages/app/src/contexts/LibraryContext.tsx
+++ b/packages/app/src/contexts/LibraryContext.tsx
@@ -1,0 +1,43 @@
+/**
+ * LibraryContext
+ *
+ * Focused context for library items, categories, and library metadata.
+ * Consumers that only need library/catalog data should prefer `useLibrary`
+ * over the broader `useWorkspace` hook.
+ *
+ * This context is backed by `WorkspaceContext` — it is not a separate provider.
+ * It re-reads the same underlying context and exposes a narrowed slice.
+ */
+import { createContext, useContext } from 'react';
+import type { LibraryItem, LibraryMeta, Category } from '../types/gridfinity';
+
+export interface LibraryContextValue {
+  // All library items across loaded libraries
+  libraryItems: LibraryItem[];
+  isLibraryLoading: boolean;
+  isLibrariesLoading: boolean;
+  libraryError: Error | null;
+  librariesError: Error | null;
+
+  // Derived categories from library items
+  categories: Category[];
+
+  // Lookup helpers
+  getItemById: (prefixedId: string) => LibraryItem | undefined;
+  getLibraryMeta: (libraryId: string) => Promise<LibraryMeta>;
+
+  // Refresh triggers
+  refreshLibraries: () => Promise<void>;
+  refreshLibrary: () => Promise<void>;
+
+  // Metadata for the currently selected item's library
+  selectedLibraryMeta: LibraryMeta;
+}
+
+export const LibraryContext = createContext<LibraryContextValue | null>(null);
+
+export function useLibrary(): LibraryContextValue {
+  const ctx = useContext(LibraryContext);
+  if (!ctx) throw new Error('useLibrary must be used within WorkspaceProvider');
+  return ctx;
+}

--- a/packages/app/src/contexts/WorkspaceContext.tsx
+++ b/packages/app/src/contexts/WorkspaceContext.tsx
@@ -201,7 +201,7 @@ export function WorkspaceProvider({ children }: WorkspaceProviderProps) {
   const [exportPdfError, setExportPdfError] = useState<string | null>(null);
   const [selectedLibraryMeta, setSelectedLibraryMeta] = useState<LibraryMeta>({
     customizableFields: [],
-    gridfinityExtendedParams: {},
+    parameters: {},
   });
 
   // Hooks

--- a/packages/app/src/contexts/WorkspaceContext.tsx
+++ b/packages/app/src/contexts/WorkspaceContext.tsx
@@ -1,14 +1,14 @@
 import { createContext, useContext, useState, useCallback, useMemo, useRef, useEffect } from 'react';
 import type { ReactNode } from 'react';
 import type {
-  UnitSystem, ImperialFormat, GridSpacerConfig, BOMItem, LibraryItem,
+  UnitSystem, ImperialFormat, GridSpacerConfig, LibraryItem,
   LibraryMeta, DragData, BinCustomization, Category,
   GridResult, ReferenceImage, PlacedItem, PlacedItemWithValidity,
   ComputedSpacer, BOMExtras,
 } from '../types/gridfinity';
 import type { SelectModifiers } from '../hooks/useGridItems';
 import type { LoadedLayoutConfig } from '../types/layoutConfig';
-import type { ApiUser } from '@gridfinity/shared';
+import type { BOMItem, ApiUser } from '@gridfinity/shared';
 import type { RefImagePlacement, UseRefImagePlacementsReturn } from '../hooks/useRefImagePlacements';
 import type { LayoutMetaState } from '../reducers/layoutMetaReducer';
 import type { DialogState, DialogAction } from '../reducers/dialogReducer';

--- a/packages/app/src/contexts/WorkspaceContext.tsx
+++ b/packages/app/src/contexts/WorkspaceContext.tsx
@@ -33,6 +33,8 @@ import { useLayoutLoader } from '../hooks/useLayoutLoader';
 import { useLayoutActions } from '../hooks/useLayoutActions';
 import { STORAGE_KEYS } from '../utils/storageKeys';
 import type { WalkthroughStep } from './WalkthroughContext';
+import { GridDimensionsContext } from './GridDimensionsContext';
+import { LibraryContext } from './LibraryContext';
 
 // Re-export for convenience
 export type { WalkthroughStep };
@@ -484,9 +486,54 @@ export function WorkspaceProvider({ children }: WorkspaceProviderProps) {
     setExportPdfError,
   };
 
+  const gridDimensionsValue = useMemo(() => ({
+    width,
+    setWidth,
+    depth,
+    setDepth,
+    unitSystem,
+    setUnitSystem,
+    imperialFormat,
+    setImperialFormat,
+    spacerConfig,
+    setSpacerConfig,
+    handleUnitChange,
+    gridResult,
+    drawerWidth,
+    drawerDepth,
+    spacers,
+  }), [
+    width, setWidth, depth, setDepth,
+    unitSystem, setUnitSystem, imperialFormat, setImperialFormat,
+    spacerConfig, setSpacerConfig, handleUnitChange,
+    gridResult, drawerWidth, drawerDepth, spacers,
+  ]);
+
+  const libraryValue = useMemo(() => ({
+    libraryItems,
+    isLibraryLoading,
+    isLibrariesLoading,
+    libraryError,
+    librariesError,
+    categories,
+    getItemById,
+    getLibraryMeta,
+    refreshLibraries,
+    refreshLibrary,
+    selectedLibraryMeta,
+  }), [
+    libraryItems, isLibraryLoading, isLibrariesLoading,
+    libraryError, librariesError, categories,
+    getItemById, getLibraryMeta, refreshLibraries, refreshLibrary, selectedLibraryMeta,
+  ]);
+
   return (
-    <WorkspaceContext.Provider value={value}>
-      {children}
-    </WorkspaceContext.Provider>
+    <GridDimensionsContext.Provider value={gridDimensionsValue}>
+      <LibraryContext.Provider value={libraryValue}>
+        <WorkspaceContext.Provider value={value}>
+          {children}
+        </WorkspaceContext.Provider>
+      </LibraryContext.Provider>
+    </GridDimensionsContext.Provider>
   );
 }

--- a/packages/app/src/hooks/__tests__/useAdmin.test.ts
+++ b/packages/app/src/hooks/__tests__/useAdmin.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement } from 'react';
+import type { ReactNode } from 'react';
+import type { ApiLayout } from '@gridfinity/shared';
+
+vi.mock('../../api/admin.api.js', () => ({
+  fetchAdminUsers: vi.fn(),
+  fetchAdminUserLayouts: vi.fn(),
+}));
+
+vi.mock('../../contexts/AuthContext.js', () => ({
+  useAuth: vi.fn(),
+}));
+
+import { useAuth } from '../../contexts/AuthContext.js';
+import { fetchAdminUsers, fetchAdminUserLayouts } from '../../api/admin.api.js';
+import { useAdminUsersQuery, useAdminUserLayoutsQuery } from '../useAdmin';
+
+const MOCK_TOKEN = 'admin-token';
+
+const MOCK_USERS = [
+  { id: 1, username: 'alice' },
+  { id: 2, username: 'bob' },
+];
+
+const MOCK_LAYOUT: ApiLayout = {
+  id: 10,
+  userId: 1,
+  name: 'My Layout',
+  description: null,
+  gridX: 4,
+  gridY: 4,
+  widthMm: 168,
+  depthMm: 168,
+  spacerHorizontal: 'none',
+  spacerVertical: 'none',
+  isPublic: false,
+  createdAt: '2024-01-01T00:00:00.000Z',
+  updatedAt: '2024-01-01T00:00:00.000Z',
+};
+
+function makeAdminAuth(overrides: Record<string, unknown> = {}) {
+  return {
+    getAccessToken: () => MOCK_TOKEN,
+    isAuthenticated: true,
+    isLoading: false,
+    user: { id: 1, email: 'admin@example.com', username: 'admin', role: 'admin' as const, createdAt: '' },
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: vi.fn(),
+    ...overrides,
+  };
+}
+
+function createWrapper() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: qc }, children);
+}
+
+describe('useAdminUsersQuery', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('fetches users when authenticated as admin', async () => {
+    vi.mocked(useAuth).mockReturnValue(makeAdminAuth());
+    vi.mocked(fetchAdminUsers).mockResolvedValue(MOCK_USERS);
+
+    const { result } = renderHook(() => useAdminUsersQuery(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(fetchAdminUsers).toHaveBeenCalledWith(MOCK_TOKEN);
+    expect(result.current.data).toEqual(MOCK_USERS);
+  });
+
+  it('does not fetch when not authenticated', async () => {
+    vi.mocked(useAuth).mockReturnValue(makeAdminAuth({ isAuthenticated: false }));
+
+    const { result } = renderHook(() => useAdminUsersQuery(), { wrapper: createWrapper() });
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(fetchAdminUsers).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch when authenticated but not admin', async () => {
+    vi.mocked(useAuth).mockReturnValue(
+      makeAdminAuth({ user: { id: 2, email: 'user@example.com', username: 'user', role: 'user', createdAt: '' } })
+    );
+
+    const { result } = renderHook(() => useAdminUsersQuery(), { wrapper: createWrapper() });
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(fetchAdminUsers).not.toHaveBeenCalled();
+  });
+
+  it('throws error when getAccessToken returns null', async () => {
+    vi.mocked(useAuth).mockReturnValue(makeAdminAuth({ getAccessToken: () => null }));
+
+    const { result } = renderHook(() => useAdminUsersQuery(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error).toEqual(new Error('Not authenticated'));
+  });
+
+  it('propagates API errors', async () => {
+    vi.mocked(useAuth).mockReturnValue(makeAdminAuth());
+    vi.mocked(fetchAdminUsers).mockRejectedValue(new Error('Server error'));
+
+    const { result } = renderHook(() => useAdminUsersQuery(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error).toEqual(new Error('Server error'));
+  });
+});
+
+describe('useAdminUserLayoutsQuery', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('fetches layouts for a given userId when authenticated as admin', async () => {
+    vi.mocked(useAuth).mockReturnValue(makeAdminAuth());
+    vi.mocked(fetchAdminUserLayouts).mockResolvedValue([MOCK_LAYOUT]);
+
+    const { result } = renderHook(() => useAdminUserLayoutsQuery(1), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(fetchAdminUserLayouts).toHaveBeenCalledWith(MOCK_TOKEN, 1);
+    expect(result.current.data).toEqual([MOCK_LAYOUT]);
+  });
+
+  it('does not fetch when userId is null', async () => {
+    vi.mocked(useAuth).mockReturnValue(makeAdminAuth());
+
+    const { result } = renderHook(() => useAdminUserLayoutsQuery(null), { wrapper: createWrapper() });
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(fetchAdminUserLayouts).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch when not admin', async () => {
+    vi.mocked(useAuth).mockReturnValue(
+      makeAdminAuth({ user: { id: 2, email: 'user@example.com', username: 'user', role: 'user', createdAt: '' } })
+    );
+
+    const { result } = renderHook(() => useAdminUserLayoutsQuery(5), { wrapper: createWrapper() });
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(fetchAdminUserLayouts).not.toHaveBeenCalled();
+  });
+
+  it('throws when getAccessToken returns null', async () => {
+    vi.mocked(useAuth).mockReturnValue(makeAdminAuth({ getAccessToken: () => null }));
+
+    const { result } = renderHook(() => useAdminUserLayoutsQuery(1), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error).toEqual(new Error('Not authenticated'));
+  });
+
+  it('propagates API errors', async () => {
+    vi.mocked(useAuth).mockReturnValue(makeAdminAuth());
+    vi.mocked(fetchAdminUserLayouts).mockRejectedValue(new Error('Forbidden'));
+
+    const { result } = renderHook(() => useAdminUserLayoutsQuery(1), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error).toEqual(new Error('Forbidden'));
+  });
+});

--- a/packages/app/src/hooks/__tests__/useAdminLayouts.test.ts
+++ b/packages/app/src/hooks/__tests__/useAdminLayouts.test.ts
@@ -131,7 +131,7 @@ describe('useAdminLayoutsQuery', () => {
     const { result } = renderHook(() => useAdminLayoutsQuery(), { wrapper: createWrapper() });
     await waitFor(() => expect(result.current.isError).toBe(true));
 
-    expect(result.current.error).toEqual(new Error('Forbidden'));
+    expect(result.current.error).toMatchObject({ message: 'Forbidden' });
   });
 
   it('returns empty array when no layouts exist', async () => {

--- a/packages/app/src/hooks/__tests__/useAdminLayouts.test.ts
+++ b/packages/app/src/hooks/__tests__/useAdminLayouts.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement } from 'react';
+import type { ReactNode } from 'react';
+import type { ApiLayout } from '@gridfinity/shared';
+
+// Mock fetch globally (useAdminLayouts uses fetch internally)
+vi.mock('../../contexts/AuthContext.js', () => ({
+  useAuth: vi.fn(),
+}));
+
+import { useAuth } from '../../contexts/AuthContext.js';
+import { useAdminLayoutsQuery } from '../useAdminLayouts';
+
+const MOCK_TOKEN = 'admin-token';
+
+const MOCK_LAYOUT: ApiLayout = {
+  id: 5,
+  userId: 1,
+  name: 'Admin Layout',
+  description: null,
+  gridX: 3,
+  gridY: 3,
+  widthMm: 126,
+  depthMm: 126,
+  spacerHorizontal: 'none',
+  spacerVertical: 'none',
+  isPublic: true,
+  createdAt: '2024-01-01T00:00:00.000Z',
+  updatedAt: '2024-01-01T00:00:00.000Z',
+};
+
+function makeAdminAuth(overrides: Record<string, unknown> = {}) {
+  return {
+    getAccessToken: () => MOCK_TOKEN,
+    isAuthenticated: true,
+    isLoading: false,
+    user: { id: 1, email: 'admin@example.com', username: 'admin', role: 'admin' as const, createdAt: '' },
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: vi.fn(),
+    ...overrides,
+  };
+}
+
+function createWrapper() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: qc }, children);
+}
+
+describe('useAdminLayoutsQuery', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+  });
+
+  it('fetches all layouts when authenticated as admin', async () => {
+    vi.mocked(useAuth).mockReturnValue(makeAdminAuth());
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: [MOCK_LAYOUT] }),
+    } as Response);
+    vi.stubGlobal('fetch', mockFetch);
+
+    const { result } = renderHook(() => useAdminLayoutsQuery(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual([MOCK_LAYOUT]);
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/admin/layouts'),
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: `Bearer ${MOCK_TOKEN}` }),
+      })
+    );
+  });
+
+  it('does not fetch when not authenticated', async () => {
+    vi.mocked(useAuth).mockReturnValue(makeAdminAuth({ isAuthenticated: false }));
+    const mockFetch = vi.fn();
+    vi.stubGlobal('fetch', mockFetch);
+
+    const { result } = renderHook(() => useAdminLayoutsQuery(), { wrapper: createWrapper() });
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch when authenticated but not admin role', async () => {
+    vi.mocked(useAuth).mockReturnValue(
+      makeAdminAuth({ user: { id: 2, email: 'u@e.com', username: 'user', role: 'user', createdAt: '' } })
+    );
+    const mockFetch = vi.fn();
+    vi.stubGlobal('fetch', mockFetch);
+
+    const { result } = renderHook(() => useAdminLayoutsQuery(), { wrapper: createWrapper() });
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('throws error when getAccessToken returns null', async () => {
+    vi.mocked(useAuth).mockReturnValue(makeAdminAuth({ getAccessToken: () => null }));
+    const mockFetch = vi.fn();
+    vi.stubGlobal('fetch', mockFetch);
+
+    const { result } = renderHook(() => useAdminLayoutsQuery(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error).toEqual(new Error('Not authenticated'));
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('throws error when fetch response is not ok', async () => {
+    vi.mocked(useAuth).mockReturnValue(makeAdminAuth());
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: async () => ({ error: { message: 'Forbidden' } }),
+    } as Response);
+    vi.stubGlobal('fetch', mockFetch);
+
+    const { result } = renderHook(() => useAdminLayoutsQuery(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error).toEqual(new Error('Forbidden'));
+  });
+
+  it('returns empty array when no layouts exist', async () => {
+    vi.mocked(useAuth).mockReturnValue(makeAdminAuth());
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: [] }),
+    } as Response);
+    vi.stubGlobal('fetch', mockFetch);
+
+    const { result } = renderHook(() => useAdminLayoutsQuery(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual([]);
+  });
+});

--- a/packages/app/src/hooks/__tests__/useLayoutActions.test.ts
+++ b/packages/app/src/hooks/__tests__/useLayoutActions.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useLayoutActions } from '../useLayoutActions';
+import type { useCloneLayoutMutation } from '../useLayouts';
+
+// Helper to create a minimal mock of the clone mutation
+function makeCloneMutation(overrides: Partial<ReturnType<typeof useCloneLayoutMutation>> = {}): ReturnType<typeof useCloneLayoutMutation> {
+  return {
+    mutateAsync: vi.fn(),
+    mutate: vi.fn(),
+    isPending: false,
+    isSuccess: false,
+    isError: false,
+    isIdle: true,
+    error: null,
+    data: undefined,
+    reset: vi.fn(),
+    status: 'idle',
+    variables: undefined,
+    context: undefined,
+    failureCount: 0,
+    failureReason: null,
+    submittedAt: 0,
+    isPaused: false,
+    ...overrides,
+  } as ReturnType<typeof useCloneLayoutMutation>;
+}
+
+describe('useLayoutActions', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe('handleSaveComplete', () => {
+    it('calls rawHandleSaveComplete with id and name', () => {
+      const rawHandleSaveComplete = vi.fn();
+      const handleCloneComplete = vi.fn();
+      const cloneLayoutMutation = makeCloneMutation();
+
+      const { result } = renderHook(() =>
+        useLayoutActions({
+          layoutId: 1,
+          cloneLayoutMutation,
+          handleCloneComplete,
+          rawHandleSaveComplete,
+        })
+      );
+
+      act(() => {
+        result.current.handleSaveComplete(42, 'My Layout');
+      });
+
+      expect(rawHandleSaveComplete).toHaveBeenCalledWith(42, 'My Layout');
+    });
+
+    it('is stable across renders when rawHandleSaveComplete does not change', () => {
+      const rawHandleSaveComplete = vi.fn();
+      const handleCloneComplete = vi.fn();
+      const cloneLayoutMutation = makeCloneMutation();
+
+      const { result, rerender } = renderHook(() =>
+        useLayoutActions({
+          layoutId: 1,
+          cloneLayoutMutation,
+          handleCloneComplete,
+          rawHandleSaveComplete,
+        })
+      );
+
+      const firstRef = result.current.handleSaveComplete;
+      rerender();
+      expect(result.current.handleSaveComplete).toBe(firstRef);
+    });
+  });
+
+  describe('handleCloneCurrentLayout', () => {
+    it('calls mutateAsync with current layoutId and then calls handleCloneComplete', async () => {
+      const handleCloneComplete = vi.fn();
+      const rawHandleSaveComplete = vi.fn();
+      const clonedLayout = { id: 99, name: 'Clone of My Layout' } as ReturnType<typeof useCloneLayoutMutation>['data'];
+      const cloneLayoutMutation = makeCloneMutation({
+        mutateAsync: vi.fn().mockResolvedValue(clonedLayout),
+      });
+
+      const { result } = renderHook(() =>
+        useLayoutActions({
+          layoutId: 5,
+          cloneLayoutMutation,
+          handleCloneComplete,
+          rawHandleSaveComplete,
+        })
+      );
+
+      await act(async () => {
+        await result.current.handleCloneCurrentLayout();
+      });
+
+      expect(cloneLayoutMutation.mutateAsync).toHaveBeenCalledWith(5);
+      expect(handleCloneComplete).toHaveBeenCalledWith(99, 'Clone of My Layout');
+    });
+
+    it('does not call mutateAsync when layoutId is null', async () => {
+      const handleCloneComplete = vi.fn();
+      const rawHandleSaveComplete = vi.fn();
+      const cloneLayoutMutation = makeCloneMutation({
+        mutateAsync: vi.fn(),
+      });
+
+      const { result } = renderHook(() =>
+        useLayoutActions({
+          layoutId: null,
+          cloneLayoutMutation,
+          handleCloneComplete,
+          rawHandleSaveComplete,
+        })
+      );
+
+      await act(async () => {
+        await result.current.handleCloneCurrentLayout();
+      });
+
+      expect(cloneLayoutMutation.mutateAsync).not.toHaveBeenCalled();
+      expect(handleCloneComplete).not.toHaveBeenCalled();
+    });
+
+    it('does not call handleCloneComplete when mutateAsync throws', async () => {
+      const handleCloneComplete = vi.fn();
+      const rawHandleSaveComplete = vi.fn();
+      const cloneLayoutMutation = makeCloneMutation({
+        mutateAsync: vi.fn().mockRejectedValue(new Error('Clone failed')),
+      });
+
+      const { result } = renderHook(() =>
+        useLayoutActions({
+          layoutId: 3,
+          cloneLayoutMutation,
+          handleCloneComplete,
+          rawHandleSaveComplete,
+        })
+      );
+
+      await act(async () => {
+        // Should not throw — errors are swallowed
+        await result.current.handleCloneCurrentLayout();
+      });
+
+      expect(handleCloneComplete).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/app/src/hooks/__tests__/useLibraries.test.ts
+++ b/packages/app/src/hooks/__tests__/useLibraries.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement } from 'react';
+import type { ReactNode } from 'react';
+import type { DataSourceAdapter } from '../../api/adapters/types';
+
+vi.mock('../../contexts/DataSourceContext.js', () => ({
+  useDataSource: vi.fn(),
+}));
+
+import { useDataSource } from '../../contexts/DataSourceContext.js';
+import { useLibraries } from '../useLibraries';
+
+const MOCK_LIBRARY_INFOS = [
+  { id: 'gridfinity-bins', name: 'Gridfinity Bins', path: '/libraries/bins', itemCount: 42 },
+  { id: 'labeled', name: 'Labeled', path: '/libraries/labeled', itemCount: 10 },
+];
+
+function makeAdapter(overrides: Partial<DataSourceAdapter> = {}): DataSourceAdapter {
+  return {
+    getLibraries: vi.fn().mockResolvedValue(MOCK_LIBRARY_INFOS),
+    getLibraryItems: vi.fn(),
+    getLibraryMeta: vi.fn(),
+    resolveImageUrl: vi.fn(),
+    ...overrides,
+  };
+}
+
+function createWrapper() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: qc }, children);
+}
+
+describe('useLibraries', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns available libraries mapped from adapter data', async () => {
+    const adapter = makeAdapter();
+    vi.mocked(useDataSource).mockReturnValue(adapter);
+
+    const { result } = renderHook(() => useLibraries(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.availableLibraries).toEqual([
+      { id: 'gridfinity-bins', name: 'Gridfinity Bins', path: '/libraries/bins', isEnabled: true, itemCount: 42 },
+      { id: 'labeled', name: 'Labeled', path: '/libraries/labeled', isEnabled: true, itemCount: 10 },
+    ]);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('sets isEnabled to true for all libraries regardless of source', async () => {
+    const adapter = makeAdapter({
+      getLibraries: vi.fn().mockResolvedValue([
+        { id: 'lib1', name: 'Library One', path: '/l1', itemCount: 5 },
+      ]),
+    });
+    vi.mocked(useDataSource).mockReturnValue(adapter);
+
+    const { result } = renderHook(() => useLibraries(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.availableLibraries[0].isEnabled).toBe(true);
+  });
+
+  it('returns empty array when adapter returns no libraries', async () => {
+    const adapter = makeAdapter({ getLibraries: vi.fn().mockResolvedValue([]) });
+    vi.mocked(useDataSource).mockReturnValue(adapter);
+
+    const { result } = renderHook(() => useLibraries(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.availableLibraries).toEqual([]);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('exposes error when adapter getLibraries rejects', async () => {
+    const adapter = makeAdapter({
+      getLibraries: vi.fn().mockRejectedValue(new Error('Network error')),
+    });
+    vi.mocked(useDataSource).mockReturnValue(adapter);
+
+    const { result } = renderHook(() => useLibraries(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.error).toBeInstanceOf(Error));
+
+    expect(result.current.error?.message).toBe('Network error');
+    expect(result.current.availableLibraries).toEqual([]);
+  });
+
+  it('is initially loading while query is in flight', () => {
+    const adapter = makeAdapter({
+      getLibraries: vi.fn().mockReturnValue(new Promise(() => {})), // never resolves
+    });
+    vi.mocked(useDataSource).mockReturnValue(adapter);
+
+    const { result } = renderHook(() => useLibraries(), { wrapper: createWrapper() });
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('refreshLibraries invalidates the libraries query', async () => {
+    const getLibraries = vi.fn()
+      .mockResolvedValueOnce(MOCK_LIBRARY_INFOS)
+      .mockResolvedValueOnce([...MOCK_LIBRARY_INFOS, { id: 'new', name: 'New', path: '/new', itemCount: 1 }]);
+    const adapter = makeAdapter({ getLibraries });
+    vi.mocked(useDataSource).mockReturnValue(adapter);
+
+    const { result } = renderHook(() => useLibraries(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(getLibraries).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await result.current.refreshLibraries();
+    });
+
+    await waitFor(() => expect(getLibraries).toHaveBeenCalledTimes(2));
+    expect(result.current.availableLibraries).toHaveLength(3);
+  });
+});

--- a/packages/app/src/hooks/useAdminLayouts.ts
+++ b/packages/app/src/hooks/useAdminLayouts.ts
@@ -1,26 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
-import type { ApiLayout } from '@gridfinity/shared';
+import type { ApiLayout, ApiResponse } from '@gridfinity/shared';
 import { useAuth } from '../contexts/AuthContext';
-
-const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? 'http://localhost:3001/api/v1';
-
-async function adminFetch<T>(path: string, accessToken: string, options: RequestInit = {}): Promise<T> {
-  const response = await fetch(`${API_BASE_URL}${path}`, {
-    ...options,
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${accessToken}`,
-      ...options.headers,
-    },
-  });
-  if (!response.ok) {
-    const errorBody = await response.json().catch(() => null);
-    const message = (errorBody as { error?: { message?: string } } | null)?.error?.message ?? `Request failed with status ${response.status}`;
-    throw new Error(message);
-  }
-  if (response.status === 204) return undefined as T;
-  return response.json() as T;
-}
+import { apiFetch } from '../api/apiClient';
 
 export function useAdminLayoutsQuery() {
   const { getAccessToken, isAuthenticated, user } = useAuth();
@@ -31,7 +12,7 @@ export function useAdminLayoutsQuery() {
     queryFn: async (): Promise<ApiLayout[]> => {
       const token = getAccessToken();
       if (!token) throw new Error('Not authenticated');
-      const result = await adminFetch<{ data: ApiLayout[] }>('/admin/layouts', token);
+      const result = await apiFetch<ApiResponse<ApiLayout[]>>('/admin/layouts', {}, token);
       return result.data;
     },
     enabled: isAuthenticated && isAdmin,

--- a/packages/app/src/hooks/useBillOfMaterials.ts
+++ b/packages/app/src/hooks/useBillOfMaterials.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
-import type { PlacedItem, BOMItem, LibraryItem, BinCustomization } from '../types/gridfinity';
+import type { BOMItem } from '@gridfinity/shared';
+import type { PlacedItem, LibraryItem, BinCustomization } from '../types/gridfinity';
 import { isDefaultCustomization, getBOMKey } from '../types/gridfinity';
 
 export function useBillOfMaterials(placedItems: PlacedItem[], libraryItems: LibraryItem[]): BOMItem[] {

--- a/packages/app/src/hooks/useBillOfMaterials.ts
+++ b/packages/app/src/hooks/useBillOfMaterials.ts
@@ -37,8 +37,8 @@ export function useBillOfMaterials(placedItems: PlacedItem[], libraryItems: Libr
           quantity: count,
           customization,
           ...(libraryItem.price !== undefined ? { price: libraryItem.price } : {}),
-          ...(libraryItem.gridfinityExtendedParams && Object.keys(libraryItem.gridfinityExtendedParams).length > 0
-            ? { gridfinityExtendedParams: libraryItem.gridfinityExtendedParams }
+          ...(libraryItem.parameters && Object.keys(libraryItem.parameters).length > 0
+            ? { parameters: libraryItem.parameters }
             : {}),
         });
       }

--- a/packages/app/src/hooks/useGridItems.ts
+++ b/packages/app/src/hooks/useGridItems.ts
@@ -202,8 +202,8 @@ export function useGridItems(
     if (!libraryItem) return;
 
     const allFields = ['wallPattern', 'lipStyle', 'fingerSlide', 'wallCutout', 'height'] as const;
-    const prefilledDefaults = libraryItem.gridfinityExtendedParams
-      ? generatorParamsToBinCustomization(libraryItem.gridfinityExtendedParams, [...allFields])
+    const prefilledDefaults = libraryItem.parameters
+      ? generatorParamsToBinCustomization(libraryItem.parameters, [...allFields])
       : {};
     const hasCustomDefaults = Object.keys(prefilledDefaults).length > 0;
 
@@ -218,8 +218,8 @@ export function useGridItems(
       customization: hasCustomDefaults
         ? { ...DEFAULT_BIN_CUSTOMIZATION, ...prefilledDefaults }
         : undefined,
-      gridfinityExtendedParams: libraryItem.gridfinityExtendedParams
-        ? mergeGeneratorParams(libraryItem.gridfinityExtendedParams)
+      parameters: libraryItem.parameters
+        ? mergeGeneratorParams(libraryItem.parameters)
         : undefined,
     };
 

--- a/packages/app/src/hooks/useLibraryData.test.ts
+++ b/packages/app/src/hooks/useLibraryData.test.ts
@@ -44,7 +44,7 @@ describe('useLibraryData', () => {
         return itemsByLibrary[libraryId] ?? [];
       },
       async getLibraryMeta(libraryId: string): Promise<LibraryMeta> {
-        return options?.metaByLibrary?.[libraryId] ?? { customizableFields: [], customizationDefaults: {} };
+        return options?.metaByLibrary?.[libraryId] ?? { customizableFields: [], parameters: {} };
       },
       resolveImageUrl(libraryId: string, imagePath: string) {
         if (imagePath.startsWith('/libraries/') || imagePath.startsWith('http')) {
@@ -381,7 +381,7 @@ describe('useLibraryData', () => {
           return mockDefaultItems;
         },
         async getLibraryMeta() {
-          return { customizableFields: [], customizationDefaults: {} };
+          return { customizableFields: [], parameters: {} };
         },
         resolveImageUrl(_libraryId: string, imagePath: string) {
           return imagePath;
@@ -432,7 +432,7 @@ describe('useLibraryData', () => {
       const { result } = renderHook(() => useLibraryData([]), { wrapper });
       const meta = await result.current.getLibraryMeta('nonexistent');
       expect(meta.customizableFields).toEqual([]);
-      expect(meta.customizationDefaults).toEqual({});
+      expect(meta.parameters).toEqual({});
     });
   });
 

--- a/packages/app/src/pages/OrderSummaryPage.tsx
+++ b/packages/app/src/pages/OrderSummaryPage.tsx
@@ -3,8 +3,8 @@ import { Link } from 'react-router-dom';
 import { useWorkspace } from '../contexts/WorkspaceContext';
 import { exportOrderSummaryPdf, calculateOrderTotal } from '../utils/exportOrderSummaryPdf';
 import { formatCustomizationDescription } from '../utils/customizationDescription';
+import type { BOMItem } from '@gridfinity/shared';
 import { getBOMKey } from '../types/gridfinity';
-import type { BOMItem } from '../types/gridfinity';
 import { BomGenerationPanel } from '../components/BomGenerationPanel';
 import './OrderSummaryPage.css';
 

--- a/packages/app/src/test/testWrapper.tsx
+++ b/packages/app/src/test/testWrapper.tsx
@@ -55,10 +55,6 @@ export function createTestWrapper(overrides?: Partial<DataSourceAdapter>) {
   };
 }
 
-/**
- * Create a test wrapper with a specific adapter and optional QueryClient.
- * Useful when you need to control the adapter or QueryClient instance directly.
- */
 export function createTestWrapperWithAdapter(
   adapter: DataSourceAdapter,
   queryClient?: QueryClient

--- a/packages/app/src/test/testWrapper.tsx
+++ b/packages/app/src/test/testWrapper.tsx
@@ -13,7 +13,7 @@ export const defaultMockAdapter: DataSourceAdapter = {
     return [];
   },
   async getLibraryMeta(): Promise<LibraryMeta> {
-    return { customizableFields: [], customizationDefaults: {} };
+    return { customizableFields: [], parameters: {} };
   },
   resolveImageUrl(libraryId: string, imagePath: string) {
     if (imagePath.startsWith('/libraries/') || imagePath.startsWith('http')) {
@@ -105,7 +105,7 @@ export function createLibraryMockAdapter(
       return items;
     },
     async getLibraryMeta(): Promise<LibraryMeta> {
-      return { customizableFields: [], customizationDefaults: {} };
+      return { customizableFields: [], parameters: {} };
     },
     resolveImageUrl(_libraryId: string, imagePath: string) {
       return imagePath;

--- a/packages/app/src/types/gridfinity.ts
+++ b/packages/app/src/types/gridfinity.ts
@@ -86,20 +86,6 @@ export interface DragData {
   refImageName?: string;
 }
 
-export interface BOMItem {
-  libraryId: string;
-  itemId: string;
-  name: string;
-  widthUnits: number;
-  heightUnits: number;
-  color: string;
-  categories: string[];
-  quantity: number;
-  customization?: BinCustomization;
-  shadowboxId?: string;
-  price?: number;
-  gridfinityExtendedParams?: GeneratorParams;
-}
 
 export interface ReferenceImage {
   id: string;

--- a/packages/app/src/types/gridfinity.ts
+++ b/packages/app/src/types/gridfinity.ts
@@ -56,8 +56,11 @@ export interface LibraryItem {
   stlFile?: string;
   imageUrl?: string;
   perspectiveImageUrl?: string;
+  perspectiveImageUrl90?: string;
+  perspectiveImageUrl180?: string;
+  perspectiveImageUrl270?: string;
   price?: number;
-  gridfinityExtendedParams?: GeneratorParams;
+  parameters?: GeneratorParams;
 }
 
 export interface PlacedItem {
@@ -70,7 +73,7 @@ export interface PlacedItem {
   rotation: Rotation;
   customization?: BinCustomization;
   shadowBoxId?: string | null;
-  gridfinityExtendedParams?: GeneratorParams;
+  parameters?: GeneratorParams;
 }
 
 export interface PlacedItemWithValidity extends PlacedItem {
@@ -148,7 +151,7 @@ export type BOMExtras = Record<string, number>;
 
 export interface LibraryMeta {
   customizableFields: CustomizableField[];
-  gridfinityExtendedParams: GeneratorParams;
+  parameters: GeneratorParams;
 }
 
 export type ImageViewMode = 'ortho' | 'perspective';
@@ -177,6 +180,6 @@ export interface LibraryIndex {
   version: string;
   items: LibraryItem[];
   customizableFields?: CustomizableField[];
-  gridfinityExtendedParams?: GeneratorParams;
+  parameters?: GeneratorParams;
   baseModel?: string;
 }

--- a/packages/app/src/types/gridfinity.ts
+++ b/packages/app/src/types/gridfinity.ts
@@ -104,12 +104,27 @@ export interface ReferenceImage {
   rotation: Rotation;
 }
 
-export type WallPattern = 'none' | 'grid' | 'hexgrid' | 'voronoi' | 'voronoigrid' | 'voronoihexgrid';
+export type WallPattern = 'none' | 'grid' | 'hexgrid' | 'brick';
 export type LipStyle = 'normal' | 'reduced' | 'minimum' | 'none';
 export type FingerSlide = 'none' | 'rounded' | 'chamfered';
 export type WallCutout = 'none' | 'vertical' | 'horizontal' | 'both';
 
 export type CustomizableField = 'wallPattern' | 'lipStyle' | 'fingerSlide' | 'wallCutout' | 'height';
+
+export interface CustomizableSelectFieldDef {
+  field: Exclude<CustomizableField, 'height'>;
+  label: string;
+  options: string[];
+}
+
+export interface CustomizableNumericFieldDef {
+  field: 'height';
+  label: string;
+  min: number;
+  max: number;
+}
+
+export type CustomizableFieldDef = CustomizableSelectFieldDef | CustomizableNumericFieldDef;
 
 export interface BinCustomization {
   wallPattern: WallPattern;
@@ -150,7 +165,7 @@ export function getBOMKey(itemId: string, customization?: BinCustomization): str
 export type BOMExtras = Record<string, number>;
 
 export interface LibraryMeta {
-  customizableFields: CustomizableField[];
+  customizableFields: CustomizableFieldDef[];
   parameters: GeneratorParams;
 }
 
@@ -179,7 +194,7 @@ export interface LibraryManifest {
 export interface LibraryIndex {
   version: string;
   items: LibraryItem[];
-  customizableFields?: CustomizableField[];
+  customizableFields?: CustomizableFieldDef[];
   parameters?: GeneratorParams;
   baseModel?: string;
 }

--- a/packages/app/src/utils/exportOrderSummaryPdf.test.ts
+++ b/packages/app/src/utils/exportOrderSummaryPdf.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { formatOrderSummaryRows, calculateOrderTotal } from './exportOrderSummaryPdf';
-import type { BOMItem } from '../types/gridfinity';
+import type { BOMItem } from '@gridfinity/shared';
 
 const item1: BOMItem = {
   itemId: 'lib1:bin1', name: 'Small Bin', widthUnits: 1, heightUnits: 1,

--- a/packages/app/src/utils/exportOrderSummaryPdf.ts
+++ b/packages/app/src/utils/exportOrderSummaryPdf.ts
@@ -1,6 +1,7 @@
 import jsPDF from 'jspdf';
 import autoTable from 'jspdf-autotable';
-import type { BOMItem, GridResult, GridSpacerConfig, UnitSystem } from '../types/gridfinity';
+import type { BOMItem } from '@gridfinity/shared';
+import type { GridResult, GridSpacerConfig, UnitSystem } from '../types/gridfinity';
 import { generateFilename, getOrientation } from './exportPdf';
 
 export function formatOrderSummaryRows(items: BOMItem[]): string[][] {

--- a/packages/app/src/utils/exportPdf.test.ts
+++ b/packages/app/src/utils/exportPdf.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { generateFilename, getOrientation, formatBomRows, exportToPdf } from './exportPdf';
 import type { ExportPdfConfig } from './exportPdf';
-import type { BOMItem, GridResult, GridSpacerConfig } from '../types/gridfinity';
+import type { BOMItem } from '@gridfinity/shared';
+import type { GridResult, GridSpacerConfig } from '../types/gridfinity';
 
 // Mock html2canvas and jspdf at module level
 vi.mock('html2canvas', () => ({

--- a/packages/app/src/utils/exportPdf.ts
+++ b/packages/app/src/utils/exportPdf.ts
@@ -1,7 +1,8 @@
 import html2canvas from 'html2canvas';
 import jsPDF from 'jspdf';
 import autoTable from 'jspdf-autotable';
-import type { BOMItem, GridResult, GridSpacerConfig, UnitSystem } from '../types/gridfinity';
+import type { BOMItem } from '@gridfinity/shared';
+import type { GridResult, GridSpacerConfig, UnitSystem } from '../types/gridfinity';
 
 export function generateFilename(layoutName?: string): string {
   if (layoutName && layoutName.trim()) {

--- a/packages/app/src/utils/generatorParams.test.ts
+++ b/packages/app/src/utils/generatorParams.test.ts
@@ -1,5 +1,15 @@
 import { describe, it, expect } from 'vitest';
 import { mergeGeneratorParams, generatorParamsToBinCustomization } from './generatorParams';
+import type { CustomizableFieldDef } from '../types/gridfinity';
+
+// Build minimal field defs for test assertions — only `field` matters for inclusion checks
+function defs(...fields: Array<'wallPattern' | 'lipStyle' | 'fingerSlide' | 'wallCutout' | 'height'>): CustomizableFieldDef[] {
+  return fields.map(f =>
+    f === 'height'
+      ? { field: f, label: 'Height', min: 1, max: 20 }
+      : { field: f, label: f, options: [] }
+  );
+}
 
 describe('mergeGeneratorParams', () => {
   it('returns empty object with no args', () => {
@@ -28,24 +38,24 @@ describe('mergeGeneratorParams', () => {
 
 describe('generatorParamsToBinCustomization', () => {
   it('maps lip_style to lipStyle when in customizableFields', () => {
-    const result = generatorParamsToBinCustomization({ lip_style: 'reduced' }, ['lipStyle']);
+    const result = generatorParamsToBinCustomization({ lip_style: 'reduced' }, defs('lipStyle'));
     expect(result.lipStyle).toBe('reduced');
   });
 
   it('ignores lip_style when lipStyle not in customizableFields', () => {
-    const result = generatorParamsToBinCustomization({ lip_style: 'reduced' }, ['wallPattern']);
+    const result = generatorParamsToBinCustomization({ lip_style: 'reduced' }, defs('wallPattern'));
     expect(result.lipStyle).toBeUndefined();
   });
 
   it('maps fingerslide to fingerSlide', () => {
-    const result = generatorParamsToBinCustomization({ fingerslide: 'rounded' }, ['fingerSlide']);
+    const result = generatorParamsToBinCustomization({ fingerslide: 'rounded' }, defs('fingerSlide'));
     expect(result.fingerSlide).toBe('rounded');
   });
 
   it('maps wallpattern_enabled: true + style to wallPattern', () => {
     const result = generatorParamsToBinCustomization(
       { wallpattern_enabled: true, wallpattern_style: 'hexgrid' },
-      ['wallPattern']
+      defs('wallPattern')
     );
     expect(result.wallPattern).toBe('hexgrid');
   });
@@ -53,7 +63,7 @@ describe('generatorParamsToBinCustomization', () => {
   it('maps wallpattern_enabled: true with no style to grid (default)', () => {
     const result = generatorParamsToBinCustomization(
       { wallpattern_enabled: true },
-      ['wallPattern']
+      defs('wallPattern')
     );
     expect(result.wallPattern).toBe('grid');
   });
@@ -61,7 +71,7 @@ describe('generatorParamsToBinCustomization', () => {
   it('maps wallpattern_enabled: false to none', () => {
     const result = generatorParamsToBinCustomization(
       { wallpattern_enabled: false },
-      ['wallPattern']
+      defs('wallPattern')
     );
     expect(result.wallPattern).toBe('none');
   });
@@ -69,25 +79,25 @@ describe('generatorParamsToBinCustomization', () => {
   it('ignores wallPattern params when wallPattern not in customizableFields', () => {
     const result = generatorParamsToBinCustomization(
       { wallpattern_enabled: true, wallpattern_style: 'grid' },
-      ['lipStyle']
+      defs('lipStyle')
     );
     expect(result.wallPattern).toBeUndefined();
   });
 
   it('maps height array [n, offset] to height n', () => {
-    const result = generatorParamsToBinCustomization({ height: [4, 0] }, ['height']);
+    const result = generatorParamsToBinCustomization({ height: [4, 0] }, defs('height'));
     expect(result.height).toBe(4);
   });
 
   it('maps height as plain number', () => {
-    const result = generatorParamsToBinCustomization({ height: 6 }, ['height']);
+    const result = generatorParamsToBinCustomization({ height: 6 }, defs('height'));
     expect(result.height).toBe(6);
   });
 
   it('maps wallcutout_enabled: true + [1,0,1,0] to vertical', () => {
     const result = generatorParamsToBinCustomization(
       { wallcutout_enabled: true, wallcutout_walls: [1, 0, 1, 0] },
-      ['wallCutout']
+      defs('wallCutout')
     );
     expect(result.wallCutout).toBe('vertical');
   });
@@ -95,7 +105,7 @@ describe('generatorParamsToBinCustomization', () => {
   it('maps wallcutout_enabled: true + [0,1,0,1] to horizontal', () => {
     const result = generatorParamsToBinCustomization(
       { wallcutout_enabled: true, wallcutout_walls: [0, 1, 0, 1] },
-      ['wallCutout']
+      defs('wallCutout')
     );
     expect(result.wallCutout).toBe('horizontal');
   });
@@ -103,33 +113,33 @@ describe('generatorParamsToBinCustomization', () => {
   it('maps wallcutout_enabled: true + [1,1,1,1] to both', () => {
     const result = generatorParamsToBinCustomization(
       { wallcutout_enabled: true, wallcutout_walls: [1, 1, 1, 1] },
-      ['wallCutout']
+      defs('wallCutout')
     );
     expect(result.wallCutout).toBe('both');
   });
 
   it('maps wallcutout_enabled: false to none', () => {
-    const result = generatorParamsToBinCustomization({ wallcutout_enabled: false }, ['wallCutout']);
+    const result = generatorParamsToBinCustomization({ wallcutout_enabled: false }, defs('wallCutout'));
     expect(result.wallCutout).toBe('none');
   });
 
   it('ignores wallCutout params when wallCutout not in customizableFields', () => {
     const result = generatorParamsToBinCustomization(
       { wallcutout_enabled: true, wallcutout_walls: [1, 1, 1, 1] },
-      ['lipStyle']
+      defs('lipStyle')
     );
     expect(result.wallCutout).toBeUndefined();
   });
 
   it('returns empty object for empty params', () => {
-    const result = generatorParamsToBinCustomization({}, ['lipStyle', 'wallPattern', 'fingerSlide', 'wallCutout', 'height']);
+    const result = generatorParamsToBinCustomization({}, defs('lipStyle', 'wallPattern', 'fingerSlide', 'wallCutout', 'height'));
     expect(result).toEqual({});
   });
 
   it('maps multiple fields at once', () => {
     const result = generatorParamsToBinCustomization(
       { lip_style: 'none', fingerslide: 'chamfered', height: [4, 0] },
-      ['lipStyle', 'fingerSlide', 'height']
+      defs('lipStyle', 'fingerSlide', 'height')
     );
     expect(result).toEqual({ lipStyle: 'none', fingerSlide: 'chamfered', height: 4 });
   });

--- a/packages/app/src/utils/generatorParams.ts
+++ b/packages/app/src/utils/generatorParams.ts
@@ -1,24 +1,28 @@
-import type { GeneratorParams, BinCustomization, CustomizableField, WallPattern, LipStyle, FingerSlide } from '../types/gridfinity';
+import type { GeneratorParams, BinCustomization, CustomizableFieldDef, WallPattern, LipStyle, FingerSlide } from '../types/gridfinity';
 
 export function mergeGeneratorParams(...layers: (GeneratorParams | undefined)[]): GeneratorParams {
   return Object.assign({}, ...layers.filter((l): l is GeneratorParams => l !== undefined));
 }
 
+function hasField(fields: CustomizableFieldDef[], name: string): boolean {
+  return fields.some(d => d.field === name);
+}
+
 export function generatorParamsToBinCustomization(
   params: GeneratorParams,
-  customizableFields: CustomizableField[]
+  customizableFields: CustomizableFieldDef[]
 ): Partial<BinCustomization> {
   const result: Partial<BinCustomization> = {};
 
-  if (customizableFields.includes('lipStyle') && params.lip_style !== undefined) {
+  if (hasField(customizableFields, 'lipStyle') && params.lip_style !== undefined) {
     result.lipStyle = params.lip_style as LipStyle;
   }
 
-  if (customizableFields.includes('fingerSlide') && params.fingerslide !== undefined) {
+  if (hasField(customizableFields, 'fingerSlide') && params.fingerslide !== undefined) {
     result.fingerSlide = params.fingerslide as FingerSlide;
   }
 
-  if (customizableFields.includes('wallPattern')) {
+  if (hasField(customizableFields, 'wallPattern')) {
     if (params.wallpattern_enabled === true) {
       result.wallPattern = ((params.wallpattern_style ?? 'grid') as WallPattern);
     } else if (params.wallpattern_enabled === false) {
@@ -26,7 +30,7 @@ export function generatorParamsToBinCustomization(
     }
   }
 
-  if (customizableFields.includes('wallCutout')) {
+  if (hasField(customizableFields, 'wallCutout')) {
     if (params.wallcutout_enabled === false) {
       result.wallCutout = 'none';
     } else if (params.wallcutout_enabled === true) {
@@ -44,7 +48,7 @@ export function generatorParamsToBinCustomization(
     }
   }
 
-  if (customizableFields.includes('height') && params.height !== undefined) {
+  if (hasField(customizableFields, 'height') && params.height !== undefined) {
     if (Array.isArray(params.height)) {
       result.height = params.height[0] as number;
     } else if (typeof params.height === 'number') {

--- a/packages/app/src/utils/migration.ts
+++ b/packages/app/src/utils/migration.ts
@@ -83,22 +83,3 @@ export function migrateLibrarySelection(): void {
     console.warn('Failed to migrate library selection:', err);
   }
 }
-
-/**
- * Clean up old localStorage keys that are no longer used
- * Safe to call even if keys don't exist
- */
-export function cleanupOldStorage(): void {
-  const keysToRemove = [
-    'gridfinity-library-custom', // Custom items no longer supported
-    'gridfinity-categories',     // Categories now derived from items
-  ];
-
-  for (const key of keysToRemove) {
-    try {
-      localStorage.removeItem(key);
-    } catch {
-      // Ignore errors - not critical
-    }
-  }
-}

--- a/packages/server/src/db/reseedLibraries.ts
+++ b/packages/server/src/db/reseedLibraries.ts
@@ -34,7 +34,7 @@ export interface LibraryIndex {
   version: string;
   baseModel?: string;
   customizableFields?: string[];
-  gridfinityExtendedParams?: Record<string, unknown>;
+  parameters?: Record<string, unknown>;
   items: LibraryItemJson[];
 }
 

--- a/packages/server/src/services/bomGeneration.service.test.ts
+++ b/packages/server/src/services/bomGeneration.service.test.ts
@@ -155,15 +155,15 @@ describe('buildGenerateParams', () => {
     expect(params.height).toEqual([8, 0]);
   });
 
-  it('customization height overrides gridfinityExtendedParams height', () => {
-    const cfg: UniqueConfig = { ...baseConfig({ height: 8 }), gridfinityExtendedParams: { height: [4, 0], filled_in: 'enabled' } };
+  it('customization height overrides parameters height', () => {
+    const cfg: UniqueConfig = { ...baseConfig({ height: 8 }), parameters: { height: [4, 0], filled_in: 'enabled' } };
     const params = buildGenerateParams(cfg);
     expect(params.height).toEqual([8, 0]);
     expect(params.filled_in).toBe('enabled');
   });
 
-  it('passes non-height gridfinityExtendedParams through', () => {
-    const cfg: UniqueConfig = { ...baseConfig({ height: 6 }), gridfinityExtendedParams: { filled_in: 'enabled' } };
+  it('passes non-height parameters through', () => {
+    const cfg: UniqueConfig = { ...baseConfig({ height: 6 }), parameters: { filled_in: 'enabled' } };
     const params = buildGenerateParams(cfg);
     expect(params.height).toEqual([6, 0]);
     expect(params.filled_in).toBe('enabled');

--- a/packages/server/src/services/bomGeneration.service.ts
+++ b/packages/server/src/services/bomGeneration.service.ts
@@ -35,7 +35,7 @@ export interface UniqueConfig {
   customization: BinCustomization;
   qty: number;
   filename: string;
-  gridfinityExtendedParams?: GeneratorParams;
+  parameters?: GeneratorParams;
   baseModelPath: string;
 }
 
@@ -110,7 +110,7 @@ export async function resolveItemSources(bomItems: BOMItem[]): Promise<{
       }
 
       const c = item.customization ?? DEFAULT_CUSTOMIZATION;
-      const defaultParams = item.gridfinityExtendedParams ?? {};
+      const defaultParams = item.parameters ?? {};
       const paramsHash = Object.keys(defaultParams).length > 0 ? hashGeneratorParams(defaultParams) : '';
       const key = `${item.widthUnits}x${item.heightUnits}::${customizationKey(item)}::${paramsHash}::${baseModelPath}`;
 
@@ -130,7 +130,7 @@ export async function resolveItemSources(bomItems: BOMItem[]): Promise<{
           customization: c,
           qty: item.quantity,
           filename,
-          gridfinityExtendedParams: Object.keys(defaultParams).length > 0 ? defaultParams : undefined,
+          parameters: Object.keys(defaultParams).length > 0 ? defaultParams : undefined,
           baseModelPath,
         });
       }
@@ -277,7 +277,7 @@ export function buildGenerateParams(cfg: UniqueConfig): Record<string, unknown> 
   const c = cfg.customization;
   const params: Record<string, unknown> = {
     ...gridfinityExtendedDefaultParams,
-    ...(cfg.gridfinityExtendedParams ?? {}),
+    ...(cfg.parameters ?? {}),
     width: [cfg.widthUnits, 0],
     depth: [cfg.heightUnits, 0],
     height: [c.height, 0],

--- a/packages/server/src/services/formatters.ts
+++ b/packages/server/src/services/formatters.ts
@@ -1,7 +1,7 @@
 import type { ApiLayout, ApiPlacedItem, BinCustomization } from '@gridfinity/shared';
 import { layouts, placedItems } from '../db/schema.js';
 
-function parseCustomization(json: string | null): BinCustomization | undefined {
+export function parseCustomization(json: string | null): BinCustomization | undefined {
   if (!json) return undefined;
   try {
     return JSON.parse(json) as BinCustomization;

--- a/packages/server/src/services/formatters.ts
+++ b/packages/server/src/services/formatters.ts
@@ -1,0 +1,51 @@
+import type { ApiLayout, ApiPlacedItem, BinCustomization } from '@gridfinity/shared';
+import { layouts, placedItems } from '../db/schema.js';
+
+function parseCustomization(json: string | null): BinCustomization | undefined {
+  if (!json) return undefined;
+  try {
+    return JSON.parse(json) as BinCustomization;
+  } catch {
+    return undefined;
+  }
+}
+
+export function formatLayout(
+  row: typeof layouts.$inferSelect,
+  ownerUsername?: string,
+  ownerEmail?: string,
+): ApiLayout {
+  return {
+    id: row.id,
+    userId: row.userId,
+    name: row.name,
+    description: row.description,
+    gridX: row.gridX,
+    gridY: row.gridY,
+    widthMm: row.widthMm,
+    depthMm: row.depthMm,
+    spacerHorizontal: row.spacerHorizontal,
+    spacerVertical: row.spacerVertical,
+    isPublic: row.isPublic,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    ...(ownerUsername !== undefined ? { ownerUsername } : {}),
+    ...(ownerEmail !== undefined ? { ownerEmail } : {}),
+  };
+}
+
+export function formatPlacedItem(row: typeof placedItems.$inferSelect): ApiPlacedItem {
+  return {
+    id: row.id,
+    layoutId: row.layoutId,
+    libraryId: row.libraryId,
+    itemId: row.itemId,
+    x: row.x,
+    y: row.y,
+    width: row.width,
+    height: row.height,
+    rotation: row.rotation,
+    sortOrder: row.sortOrder,
+    ...(row.customization ? { customization: parseCustomization(row.customization) } : {}),
+  };
+}

--- a/packages/server/src/services/layout.service.ts
+++ b/packages/server/src/services/layout.service.ts
@@ -5,6 +5,7 @@ import { db } from '../db/connection.js';
 import { layouts, placedItems, userStorage, referenceImages, refImages, users } from '../db/schema.js';
 import * as referenceImageService from './referenceImage.service.js';
 import { formatLayout, formatPlacedItem } from './formatters.js';
+import { ensureStorageRow } from './storage.helpers.js';
 
 interface CursorData {
   createdAt: string;
@@ -191,25 +192,6 @@ interface CreateLayoutData {
     isLocked: boolean;
     rotation: number;
   }>;
-}
-
-async function ensureStorageRow(userId: number): Promise<typeof userStorage.$inferSelect> {
-  const existing = await db
-    .select()
-    .from(userStorage)
-    .where(eq(userStorage.userId, userId))
-    .limit(1);
-
-  if (existing.length > 0) {
-    return existing[0];
-  }
-
-  const inserted = await db
-    .insert(userStorage)
-    .values({ userId, layoutCount: 0, imageBytes: 0 })
-    .returning();
-
-  return inserted[0];
 }
 
 export async function createLayout(

--- a/packages/server/src/services/layout.service.ts
+++ b/packages/server/src/services/layout.service.ts
@@ -1,9 +1,10 @@
 import { eq, and, lt, desc, sql, or } from 'drizzle-orm';
 import { AppError, ErrorCodes } from '@gridfinity/shared';
-import type { ApiLayout, ApiLayoutDetail, ApiPlacedItem, ApiRefImagePlacement, BinCustomization } from '@gridfinity/shared';
+import type { ApiLayout, ApiLayoutDetail, ApiRefImagePlacement, BinCustomization } from '@gridfinity/shared';
 import { db } from '../db/connection.js';
 import { layouts, placedItems, userStorage, referenceImages, refImages, users } from '../db/schema.js';
 import * as referenceImageService from './referenceImage.service.js';
+import { formatLayout, formatPlacedItem } from './formatters.js';
 
 interface CursorData {
   createdAt: string;
@@ -27,51 +28,6 @@ function decodeCursor(cursor: string): CursorData {
   } catch {
     throw new AppError(ErrorCodes.VALIDATION_ERROR, 'Invalid cursor');
   }
-}
-
-function formatLayout(row: typeof layouts.$inferSelect, ownerUsername?: string, ownerEmail?: string): ApiLayout {
-  return {
-    id: row.id,
-    userId: row.userId,
-    name: row.name,
-    description: row.description,
-    gridX: row.gridX,
-    gridY: row.gridY,
-    widthMm: row.widthMm,
-    depthMm: row.depthMm,
-    spacerHorizontal: row.spacerHorizontal,
-    spacerVertical: row.spacerVertical,
-    isPublic: row.isPublic,
-    createdAt: row.createdAt,
-    updatedAt: row.updatedAt,
-    ...(ownerUsername !== undefined ? { ownerUsername } : {}),
-    ...(ownerEmail !== undefined ? { ownerEmail } : {}),
-  };
-}
-
-function parseCustomization(json: string | null): BinCustomization | undefined {
-  if (!json) return undefined;
-  try {
-    return JSON.parse(json) as BinCustomization;
-  } catch {
-    return undefined;
-  }
-}
-
-function formatPlacedItem(row: typeof placedItems.$inferSelect): ApiPlacedItem {
-  return {
-    id: row.id,
-    layoutId: row.layoutId,
-    libraryId: row.libraryId,
-    itemId: row.itemId,
-    x: row.x,
-    y: row.y,
-    width: row.width,
-    height: row.height,
-    rotation: row.rotation,
-    sortOrder: row.sortOrder,
-    ...(row.customization ? { customization: parseCustomization(row.customization) } : {}),
-  };
 }
 
 function unprefixItemId(prefixedId: string): { libraryId: string; itemId: string } {

--- a/packages/server/src/services/refImage.service.ts
+++ b/packages/server/src/services/refImage.service.ts
@@ -4,6 +4,7 @@ import type { ApiRefImage } from '@gridfinity/shared';
 import { db } from '../db/connection.js';
 import { refImages, userStorage } from '../db/schema.js';
 import * as imageService from './image.service.js';
+import { ensureStorageRow } from './storage.helpers.js';
 
 function formatRefImage(row: typeof refImages.$inferSelect): ApiRefImage {
   return {
@@ -15,25 +16,6 @@ function formatRefImage(row: typeof refImages.$inferSelect): ApiRefImage {
     fileSize: row.fileSize,
     createdAt: row.createdAt,
   };
-}
-
-async function ensureStorageRow(userId: number): Promise<typeof userStorage.$inferSelect> {
-  const existing = await db
-    .select()
-    .from(userStorage)
-    .where(eq(userStorage.userId, userId))
-    .limit(1);
-
-  if (existing.length > 0) {
-    return existing[0];
-  }
-
-  const inserted = await db
-    .insert(userStorage)
-    .values({ userId, layoutCount: 0, imageBytes: 0 })
-    .returning();
-
-  return inserted[0];
 }
 
 export async function listRefImages(userId: number): Promise<ApiRefImage[]> {

--- a/packages/server/src/services/referenceImage.service.ts
+++ b/packages/server/src/services/referenceImage.service.ts
@@ -4,6 +4,7 @@ import type { ApiReferenceImage } from '@gridfinity/shared';
 import { db } from '../db/connection.js';
 import { referenceImages, layouts, userStorage } from '../db/schema.js';
 import * as imageService from './image.service.js';
+import { ensureStorageRow } from './storage.helpers.js';
 
 function formatReferenceImage(
   row: typeof referenceImages.$inferSelect,
@@ -35,25 +36,6 @@ export async function getReferenceImagesByLayout(
     .orderBy(referenceImages.id);
 
   return rows.map(formatReferenceImage);
-}
-
-async function ensureStorageRow(userId: number): Promise<typeof userStorage.$inferSelect> {
-  const existing = await db
-    .select()
-    .from(userStorage)
-    .where(eq(userStorage.userId, userId))
-    .limit(1);
-
-  if (existing.length > 0) {
-    return existing[0];
-  }
-
-  const inserted = await db
-    .insert(userStorage)
-    .values({ userId, layoutCount: 0, imageBytes: 0 })
-    .returning();
-
-  return inserted[0];
 }
 
 export async function uploadReferenceImage(

--- a/packages/server/src/services/share.service.ts
+++ b/packages/server/src/services/share.service.ts
@@ -1,9 +1,10 @@
 import { eq, and, sql } from 'drizzle-orm';
 import { nanoid } from 'nanoid';
 import { AppError, ErrorCodes } from '@gridfinity/shared';
-import type { ApiSharedProject, ApiSharedLayoutView, ApiPlacedItem, ApiLayout } from '@gridfinity/shared';
+import type { ApiSharedProject, ApiSharedLayoutView } from '@gridfinity/shared';
 import { db } from '../db/connection.js';
 import { sharedProjects, layouts, placedItems, users } from '../db/schema.js';
+import { formatLayout, formatPlacedItem } from './formatters.js';
 
 function formatSharedProject(row: typeof sharedProjects.$inferSelect): ApiSharedProject {
   return {
@@ -14,39 +15,6 @@ function formatSharedProject(row: typeof sharedProjects.$inferSelect): ApiShared
     expiresAt: row.expiresAt,
     viewCount: row.viewCount,
     createdAt: row.createdAt,
-  };
-}
-
-function formatLayout(row: typeof layouts.$inferSelect): ApiLayout {
-  return {
-    id: row.id,
-    userId: row.userId,
-    name: row.name,
-    description: row.description,
-    gridX: row.gridX,
-    gridY: row.gridY,
-    widthMm: row.widthMm,
-    depthMm: row.depthMm,
-    spacerHorizontal: row.spacerHorizontal,
-    spacerVertical: row.spacerVertical,
-    isPublic: row.isPublic,
-    createdAt: row.createdAt,
-    updatedAt: row.updatedAt,
-  };
-}
-
-function formatPlacedItem(row: typeof placedItems.$inferSelect): ApiPlacedItem {
-  return {
-    id: row.id,
-    layoutId: row.layoutId,
-    libraryId: row.libraryId,
-    itemId: row.itemId,
-    x: row.x,
-    y: row.y,
-    width: row.width,
-    height: row.height,
-    rotation: row.rotation,
-    sortOrder: row.sortOrder,
   };
 }
 

--- a/packages/server/src/services/storage.helpers.ts
+++ b/packages/server/src/services/storage.helpers.ts
@@ -1,0 +1,22 @@
+import { eq } from 'drizzle-orm';
+import { db } from '../db/connection.js';
+import { userStorage } from '../db/schema.js';
+
+export async function ensureStorageRow(userId: number): Promise<typeof userStorage.$inferSelect> {
+  const existing = await db
+    .select()
+    .from(userStorage)
+    .where(eq(userStorage.userId, userId))
+    .limit(1);
+
+  if (existing.length > 0) {
+    return existing[0];
+  }
+
+  const inserted = await db
+    .insert(userStorage)
+    .values({ userId, layoutCount: 0, imageBytes: 0 })
+    .returning();
+
+  return inserted[0];
+}

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -111,7 +111,7 @@ export interface BOMItem {
   quantity: number;
   customization?: BinCustomization;
   price?: number;
-  gridfinityExtendedParams?: GeneratorParams;
+  parameters?: GeneratorParams;
 }
 
 export interface ReferenceImage {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -110,6 +110,7 @@ export interface BOMItem {
   categories: string[];
   quantity: number;
   customization?: BinCustomization;
+  price?: number;
   gridfinityExtendedParams?: GeneratorParams;
 }
 


### PR DESCRIPTION
## Summary

- **parameter-options**: `customizableFields` in all three `index.json` libraries changed from a string array to typed objects with `field`, `label`, and either `options` (select) or `min`/`max` (numeric). Libraries are now self-describing — no hardcoded option arrays in components. Voronoi wall patterns excluded; `brick` added as a valid option. `WallPattern` type narrowed to `none | grid | hexgrid | brick`.
- **code-quality-improvements** (included, not yet in develop): refactors across server/client — consolidate BOMItem to shared package, extract layout formatters, consolidate reference image services, split WorkspaceContext, fix API client issues, add test coverage for hooks and components.

All 1530 tests passing (1285 frontend, 245 server).

## Test plan

- [ ] Run `npm run test:run` — 1530 tests pass
- [ ] Spot-check customization panel in dev server: wall pattern dropdown shows none/grid/hexgrid/brick only
- [ ] Verify shadowbox height field respects min=1 max=20 from def

🤖 Generated with [Claude Code](https://claude.com/claude-code)