### PR TITLE
fix(customization): remove invalid 'brick' wall pattern option

### DIFF
--- a/packages/app/public/libraries/bins_labeled/index.json
+++ b/packages/app/public/libraries/bins_labeled/index.json
@@ -3,7 +3,7 @@
   "baseModel": "gridfinity_basic_cup.scad",
   "customizableFields": [
     { "field": "wallPatternEnabled", "label": "Wall Pattern" },
-    { "field": "wallPattern", "label": "Wall Pattern", "options": ["grid", "hexgrid", "brick"] },
+    { "field": "wallPattern", "label": "Wall Pattern", "options": ["grid", "hexgrid"] },
     { "field": "lipStyle",    "label": "Lip Style",    "options": ["normal", "reduced", "minimum", "none"] },
     { "field": "fingerSlide", "label": "Finger Slide", "options": ["none", "rounded", "chamfered"] },
     { "field": "wallCutout", "label": "Wall Cutout" },

--- a/packages/app/public/libraries/bins_standard/index.json
+++ b/packages/app/public/libraries/bins_standard/index.json
@@ -3,7 +3,7 @@
   "baseModel": "gridfinity_basic_cup.scad",
   "customizableFields": [
     { "field": "wallPatternEnabled", "label": "Wall Pattern" },
-    { "field": "wallPattern", "label": "Wall Pattern", "options": ["grid", "hexgrid", "brick"] },
+    { "field": "wallPattern", "label": "Wall Pattern", "options": ["grid", "hexgrid"] },
     { "field": "lipStyle",    "label": "Lip Style",    "options": ["normal", "reduced", "minimum", "none"] },
     { "field": "fingerSlide", "label": "Finger Slide", "options": ["none", "rounded", "chamfered"] },
     { "field": "wallCutout", "label": "Wall Cutout" },

--- a/packages/app/src/components/BinCustomizationPanel.test.tsx
+++ b/packages/app/src/components/BinCustomizationPanel.test.tsx
@@ -6,7 +6,7 @@ import { DEFAULT_BIN_CUSTOMIZATION } from '../types/gridfinity';
 
 const ALL_FIELDS: CustomizableFieldDef[] = [
   { field: 'wallPatternEnabled', label: 'Wall Pattern' },
-  { field: 'wallPattern', label: 'Wall Pattern', options: ['grid', 'hexgrid', 'brick'] },
+  { field: 'wallPattern', label: 'Wall Pattern', options: ['grid', 'hexgrid'] },
   { field: 'lipStyle',    label: 'Lip Style',    options: ['normal', 'reduced', 'minimum', 'none'] },
   { field: 'fingerSlide', label: 'Finger Slide', options: ['none', 'rounded', 'chamfered'] },
   { field: 'wallCutout',  label: 'Wall Cutout' },
@@ -261,11 +261,11 @@ describe('BinCustomizationPanel', () => {
       );
 
       const wallPatternStyleSelect = screen.getByLabelText('Style');
-      fireEvent.change(wallPatternStyleSelect, { target: { value: 'brick' } });
+      fireEvent.change(wallPatternStyleSelect, { target: { value: 'hexgrid' } });
 
       expect(mockOnChange).toHaveBeenCalledWith({
         wallPatternEnabled: true,
-        wallPattern: 'brick',
+        wallPattern: 'hexgrid',
         lipStyle: 'reduced',
         fingerSlide: 'rounded',
         wallCutout: { front: true, back: false, left: false, right: false },
@@ -458,9 +458,9 @@ describe('BinCustomizationPanel', () => {
 
       expect(options).toContain('grid');
       expect(options).toContain('hexgrid');
-      expect(options).toContain('brick');
+      expect(options).not.toContain('brick');
       expect(options).not.toContain('none');
-      expect(options).toHaveLength(3);
+      expect(options).toHaveLength(2);
     });
 
     it('should not show style select when wall pattern is disabled', () => {

--- a/packages/app/src/components/PlacedItemOverlay.test.tsx
+++ b/packages/app/src/components/PlacedItemOverlay.test.tsx
@@ -86,7 +86,7 @@ describe('PlacedItemOverlay', () => {
   const mockGetLibraryMeta = vi.fn().mockResolvedValue({
     customizableFields: [
       { field: 'wallPatternEnabled', label: 'Wall Pattern' },
-      { field: 'wallPattern', label: 'Wall Pattern', options: ['grid', 'hexgrid', 'brick'] },
+      { field: 'wallPattern', label: 'Wall Pattern', options: ['grid', 'hexgrid'] },
       { field: 'lipStyle',    label: 'Lip Style',    options: ['normal', 'reduced', 'minimum', 'none'] },
       { field: 'fingerSlide', label: 'Finger Slide', options: ['none', 'rounded', 'chamfered'] },
       { field: 'wallCutout',  label: 'Wall Cutout' },

--- a/packages/app/src/hooks/useGridItems.test.ts
+++ b/packages/app/src/hooks/useGridItems.test.ts
@@ -426,7 +426,7 @@ describe('useGridItems', () => {
   describe('addItemWithCustomization', () => {
     const customization: BinCustomization = {
       wallPatternEnabled: true,
-      wallPattern: 'brick',
+      wallPattern: 'hexgrid',
       lipStyle: 'minimum',
       fingerSlide: 'chamfered',
       wallCutout: 'horizontal',

--- a/packages/app/src/types/gridfinity.ts
+++ b/packages/app/src/types/gridfinity.ts
@@ -108,7 +108,7 @@ export interface ReferenceImage {
   rotation: Rotation;
 }
 
-export type WallPattern = 'grid' | 'hexgrid' | 'brick' | 'voronoi' | 'voronoigrid' | 'voronoihexgrid';
+export type WallPattern = 'grid' | 'hexgrid' | 'voronoi' | 'voronoigrid' | 'voronoihexgrid';
 export type LipStyle = 'normal' | 'reduced' | 'minimum' | 'none';
 export type FingerSlide = 'none' | 'rounded' | 'chamfered';
 export interface WallCutoutConfig {

--- a/packages/server/src/controllers/favorites.controller.ts
+++ b/packages/server/src/controllers/favorites.controller.ts
@@ -5,7 +5,7 @@ import * as favoritesService from '../services/favorites.service.js';
 
 const binCustomizationSchema = z.object({
   wallPatternEnabled: z.boolean().default(false),
-  wallPattern: z.enum(['grid', 'hexgrid', 'brick', 'voronoi', 'voronoigrid', 'voronoihexgrid']),
+  wallPattern: z.enum(['grid', 'hexgrid', 'voronoi', 'voronoigrid', 'voronoihexgrid']),
   lipStyle: z.enum(['normal', 'reduced', 'minimum', 'none']),
   fingerSlide: z.enum(['none', 'rounded', 'chamfered']),
   wallCutout: z.object({

--- a/packages/server/src/controllers/layout.controller.ts
+++ b/packages/server/src/controllers/layout.controller.ts
@@ -19,7 +19,7 @@ const binCustomizationSchema = z.preprocess(
   },
   z.object({
     wallPatternEnabled: z.boolean().default(false),
-    wallPattern: z.enum(['grid', 'hexgrid', 'brick', 'voronoi', 'voronoigrid', 'voronoihexgrid']),
+    wallPattern: z.enum(['grid', 'hexgrid', 'voronoi', 'voronoigrid', 'voronoihexgrid']),
     lipStyle: z.enum(['normal', 'reduced', 'minimum', 'none']),
     fingerSlide: z.enum(['none', 'rounded', 'chamfered']),
     wallCutout: z.object({

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -58,7 +58,7 @@ export interface LibraryItem {
   perspectiveImageUrl?: string;
 }
 
-export type WallPattern = 'grid' | 'hexgrid' | 'brick' | 'voronoi' | 'voronoigrid' | 'voronoihexgrid';
+export type WallPattern = 'grid' | 'hexgrid' | 'voronoi' | 'voronoigrid' | 'voronoihexgrid';
 export type LipStyle = 'normal' | 'reduced' | 'minimum' | 'none';
 export type FingerSlide = 'none' | 'rounded' | 'chamfered';
 export interface WallCutoutConfig {


### PR DESCRIPTION
## Summary

- Removes `'brick'` from `wallPattern` options in `bins_standard` and `bins_labeled` library definitions
- Removes `'brick'` from the `WallPattern` TypeScript type (app and shared packages)
- Removes `'brick'` from Zod validation enums in layout and favorites controllers

## Root cause

`'brick'` is not a valid `wallpattern_style` value in the OpenSCAD gridfinity-extended generator. Selecting it passed an unrecognized string that OpenSCAD silently ignored, so the model never changed. Brick is actually a separate pattern modifier (`wallpattern_pattern_brick_weight`), not a standalone style.

## Test plan
- [x] All 1639 unit tests pass
- [x] ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)