### PR TITLE
feat(server): add info-level logging to generation and STL processing

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - JWT_REFRESH_SECRET=${JWT_REFRESH_SECRET}
       - CORS_ORIGIN=http://localhost:32888
       - ADMIN_INITIAL_PASSWORD=admin
+      - LOG_LEVEL=info
     volumes:
       - gridfinity-data:/config
       - gridfinity-data-files:/data

--- a/packages/server/src/services/generationPipeline.service.ts
+++ b/packages/server/src/services/generationPipeline.service.ts
@@ -3,6 +3,7 @@ import { spawn } from 'child_process';
 import fs from 'fs/promises';
 import path from 'path';
 import { config } from '../config.js';
+import { logger } from '../logger.js';
 
 const PYTHON_CMD = process.platform === 'win32' ? 'python' : 'python3';
 
@@ -10,13 +11,18 @@ export type GenerationStatus = 'pending' | 'complete' | 'failed' | 'not-found';
 
 function runPython(args: string[]): Promise<void> {
   return new Promise((resolve, reject) => {
+    let stdout = '';
     let stderr = '';
     const child = spawn(PYTHON_CMD, args);
-    child.stdout.on('data', () => {});
+    child.stdout.on('data', (chunk: Buffer) => { stdout += chunk.toString(); });
     child.stderr.on('data', (chunk: Buffer) => { stderr += chunk.toString(); });
     child.on('close', (code) => {
-      if (code === 0) resolve();
-      else reject(new Error(`${args[0]} exited ${code}: ${stderr.trim()}`));
+      if (code === 0) {
+        if (stdout.trim()) logger.debug({ script: path.basename(args[0]), output: stdout.trim() }, 'python stdout');
+        resolve();
+      } else {
+        reject(new Error(`${args[0]} exited ${code}: ${stderr.trim()}`));
+      }
     });
     child.on('error', reject);
   });
@@ -138,9 +144,11 @@ export class GenerationPipelineService extends EventEmitter {
     const stlToPngScript = path.join(this.libraryBuilderDir, 'stl_to_png.py');
 
     try {
+      logger.info({ hash, subdir }, 'generation: rendering STL');
       await fs.writeFile(paramsFile, JSON.stringify(params));
       await runPython([generateScript, paramsFile, '--output', stlFile, '--model', baseModelPath]);
 
+      logger.info({ hash, subdir }, 'generation: STL ready, rendering thumbnails');
       const orthoPng = path.join(dir, 'ortho.png');
       await runPython([stlToPngScript, stlFile, '--orthographic', '-o', orthoPng]);
       for (const rotation of [0, 90, 180, 270]) {
@@ -151,9 +159,11 @@ export class GenerationPipelineService extends EventEmitter {
         ]);
       }
 
+      logger.info({ hash, subdir }, 'generation: complete');
       this.emit('generation:complete', { hash });
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
+      logger.error({ hash, subdir, err: msg }, 'generation: failed');
       await fs.writeFile(path.join(dir, 'error.txt'), msg).catch(() => {});
       this.emit('generation:failed', { hash, error: msg });
     }

--- a/packages/server/src/services/stlProcessing.service.ts
+++ b/packages/server/src/services/stlProcessing.service.ts
@@ -34,6 +34,7 @@ export function processUpload(
       child.on('close', resolve);
     });
 
+    logger.info({ uploadId }, 'STL processing: started');
     await updateUploadStatus(client, uploadId, 'processing');
 
     const code = await childClosed;
@@ -46,6 +47,7 @@ export function processUpload(
           imageUrl: string;
           perspImageUrls: string[];
         };
+        logger.info({ uploadId, gridX: result.gridX, gridY: result.gridY }, 'STL processing: complete');
         await updateUploadStatus(client, uploadId, 'ready', {
           gridX: result.gridX,
           gridY: result.gridY,


### PR DESCRIPTION
## Summary
- `generationPipeline.service.ts`: logs `generation: rendering STL`, `generation: STL ready, rendering thumbnails`, `generation: complete`, and `generation: failed` at `info`/`error` level; captures Python stdout at `debug` level instead of discarding it
- `stlProcessing.service.ts`: logs `STL processing: started` and `STL processing: complete` (with grid dimensions) at `info` level
- `infra/docker-compose.yml`: sets `LOG_LEVEL=info` so these logs surface locally (the Docker image default remains `warn`)

## Test Plan
- [ ] `npm run test:run` passes (log lines visible in test output confirms wiring)
- [ ] Trigger a generation and verify entries appear in `docker compose logs -f`