### PR TITLE
fix(infra): remove LIBRARIES_DIR from Dockerfile ENV to restore seeding

### DIFF
--- a/infra/Dockerfile
+++ b/infra/Dockerfile
@@ -92,7 +92,6 @@ ENV NODE_ENV=production \
     IMAGE_DIR=/data/images \
     USER_STL_DIR=/data/user-stls \
     USER_STL_IMAGE_DIR=/data/user-stl-images \
-    LIBRARIES_DIR=/data/libraries \
     CORS_ORIGIN=http://localhost:8080 \
     GRIDFINITY_GENERATOR_DIR=/app/tools/gridfinity-generator \
     LIBRARY_BUILDER_DIR=/app/tools/library-builder \


### PR DESCRIPTION
## Root Cause
`LIBRARIES_DIR=/data/libraries` in the Dockerfile ENV caused `reseedLibraries.ts` to look for the library manifest in the (empty) data volume instead of falling back to the baked-in libraries at `packages/app/public/libraries/`. This meant:
- Fresh containers never seeded the DB
- Stale `base_model_path` values from old containers pointed to paths that no longer exist (`/app/packages/server/data/generator-models/`)
- All generation jobs failed with `generate_bin.py exited 1:` (empty stderr, since the SCAD-not-found message goes to stdout)
- Library preview images and customization thumbnails never rendered

## Fix
Remove `LIBRARIES_DIR` from the Dockerfile `ENV` block so `process.env.LIBRARIES_DIR` is undefined, triggering the fallback to the public libraries directory. Users who want custom libraries can still set `LIBRARIES_DIR` in their compose/env file.

## Verified
Rebuilt locally — seeding logs show 5 libraries / 83 items found, and all generation jobs start queuing immediately.