### PR TITLE
fix(infra): remove LIBRARIES_DIR from Dockerfile ENV to restore seeding

### DIFF
--- a/infra/Dockerfile
+++ b/infra/Dockerfile
@@ -92,7 +92,6 @@ ENV NODE_ENV=production \
     IMAGE_DIR=/data/images \
     USER_STL_DIR=/data/user-stls \
     USER_STL_IMAGE_DIR=/data/user-stl-images \
-    LIBRARIES_DIR=/data/libraries \
     CORS_ORIGIN=http://localhost:8080 \
     GRIDFINITY_GENERATOR_DIR=/app/tools/gridfinity-generator \
     LIBRARY_BUILDER_DIR=/app/tools/library-builder \


### PR DESCRIPTION
Fixes library seeding on fresh containers. See PR #129 for full details.