### PR TITLE
feat(3mf): 3MF spec compliance and 3D perspective plate thumbnails

### DIFF
--- a/generator/bundle_3mf.py
+++ b/generator/bundle_3mf.py
@@ -6,6 +6,7 @@ Usage:
 
 manifest.json: [{"filename": "bin_2x3x8.stl", "widthUnits": 2, "heightUnits": 3, "qty": 4, "customization": {...}}]
 """
+import io
 import json
 import os
 import struct
@@ -13,6 +14,11 @@ import sys
 import textwrap
 import zipfile
 from io import StringIO
+
+import matplotlib
+matplotlib.use('Agg')  # headless backend — must precede pyplot import
+import matplotlib.pyplot as plt
+import numpy as np
 
 GRIDFINITY_UNIT_MM = 42.0
 ITEM_GAP_MM = 2.0
@@ -133,6 +139,10 @@ def _mesh_to_xml(object_id: int, vertices: list, triangles: list) -> str:
     return buf.getvalue()
 
 
+# TODO: expose PLATE_WIDTH_MM / PLATE_DEPTH_MM as CLI arguments (and eventually a UI input)
+# so users can target different build volumes without editing source.
+
+
 def _component_to_xml(wrapper_id: int, mesh_id: int) -> str:
     """Render a component-wrapper <object> that references a shared mesh object.
 
@@ -202,6 +212,120 @@ def autoarrange_plates(instances: list) -> list:
 
     commit_plate()
     return plates
+
+
+THUMBNAIL_PX = 512
+_BG_COLOR = '#0d0d14'
+_PLATE_COLOR = '#1a1a28'
+_GRID_COLOR = '#2a2a3c'
+_BIN_COLOR = '#3B82F6'
+
+
+def generate_plate_thumbnail(
+    plate_items: list,
+    mesh_by_filename: dict,
+    plate_width_mm: float = PLATE_WIDTH_MM,
+    plate_depth_mm: float = PLATE_DEPTH_MM,
+) -> bytes:
+    """Render a perspective PNG thumbnail of one plate using actual STL geometry.
+
+    plate_items: placed items from autoarrange_plates (each has x, y, filename)
+    mesh_by_filename: filename → (object_id, vertices, triangles) from parse_binary_stl
+    Returns raw PNG bytes for embedding in the 3MF ZIP.
+    """
+    fig = plt.figure(figsize=(THUMBNAIL_PX / 100, THUMBNAIL_PX / 100), dpi=100)
+    fig.patch.set_facecolor(_BG_COLOR)
+    ax = fig.add_axes([0, 0, 1, 1], projection='3d')
+    ax.patch.set_facecolor(_BG_COLOR)
+
+    # Plate surface
+    px = np.array([[0, plate_width_mm], [0, plate_width_mm]])
+    py = np.array([[0, 0], [plate_depth_mm, plate_depth_mm]])
+    ax.plot_surface(px, py, np.zeros_like(px), color=_PLATE_COLOR, linewidth=0, zorder=0)
+
+    # Gridfinity unit grid lines on the plate floor
+    for gx in np.arange(GRIDFINITY_UNIT_MM, plate_width_mm, GRIDFINITY_UNIT_MM):
+        ax.plot([gx, gx], [0, plate_depth_mm], [0, 0], color=_GRID_COLOR, linewidth=0.5, zorder=1)
+    for gy in np.arange(GRIDFINITY_UNIT_MM, plate_depth_mm, GRIDFINITY_UNIT_MM):
+        ax.plot([0, plate_width_mm], [gy, gy], [0, 0], color=_GRID_COLOR, linewidth=0.5, zorder=1)
+
+    max_z = 10.0
+    for item in plate_items:
+        _, vertices, triangles = mesh_by_filename[item['filename']]
+        verts = np.array(vertices, dtype=np.float64)
+        tris = np.array(triangles, dtype=np.int32)
+        verts[:, 0] += item['x']
+        verts[:, 1] += item['y']
+        max_z = max(max_z, float(verts[:, 2].max()))
+        ax.plot_trisurf(
+            verts[:, 0], verts[:, 1], verts[:, 2],
+            triangles=tris,
+            color=_BIN_COLOR,
+            shade=True,
+            linewidth=0,
+            antialiased=False,
+            zorder=2,
+        )
+
+    ax.set_xlim(0, plate_width_mm)
+    ax.set_ylim(0, plate_depth_mm)
+    ax.set_zlim(0, max_z)
+    # Compress Z so bins don't dominate — keep plate footprint prominent
+    ax.set_box_aspect([plate_width_mm, plate_depth_mm, max_z * 1.2])
+    ax.view_init(elev=35, azim=-50)
+    ax.set_axis_off()
+
+    buf = io.BytesIO()
+    fig.savefig(buf, format='png', facecolor=_BG_COLOR, edgecolor='none',
+                bbox_inches='tight', dpi=100)
+    plt.close(fig)
+    return buf.getvalue()
+
+
+def build_model_settings_xml(plate_obj_ids: list, plate_thumbnails: list | None = None) -> str:
+    """Build OrcaSlicer-compatible Metadata/model_settings.config XML.
+
+    plate_obj_ids: list of plates; each plate is a list of wrapper object IDs
+    (the XML `id` attribute of the component-wrapper <object> elements that
+    appear as <item> entries in <build>).
+
+    OrcaSlicer identifies plate membership via <model_instance> children, each
+    carrying three <metadata> elements:
+      - object_id:   the wrapper's XML object ID from 3dmodel.model
+      - instance_id: 0-based instance index within that object (always 0 here
+                     since every wrapper is instantiated exactly once in <build>)
+      - identify_id: stable unique identifier (we reuse the object ID)
+
+    See: OrcaSlicer src/libslic3r/Format/bbs_3mf.cpp (INSTANCE_TAG, PLATERID_ATTR)
+    """
+    plate_sections: list = []
+    for plate_idx, obj_ids in enumerate(plate_obj_ids, start=1):
+        thumb_path = (plate_thumbnails or [])[plate_idx - 1] if plate_thumbnails else None
+        thumb_line = f'  <metadata key="thumbnail_file" value="{thumb_path}"/>\n' if thumb_path else ''
+        instance_lines = []
+        for oid in obj_ids:
+            instance_lines.append(
+                f'  <model_instance>\n'
+                f'    <metadata key="object_id" value="{oid}"/>\n'
+                f'    <metadata key="instance_id" value="0"/>\n'
+                f'    <metadata key="identify_id" value="{oid}"/>\n'
+                f'  </model_instance>'
+            )
+        plate_sections.append(
+            f'<plate>\n'
+            f'  <metadata key="plater_id" value="{plate_idx}"/>\n'
+            f'  <metadata key="plater_name" value="Plate {plate_idx}"/>\n'
+            f'  <metadata key="locked" value="false"/>\n'
+            + thumb_line
+            + '\n'.join(instance_lines) + '\n'
+            + '</plate>'
+        )
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<config>\n'
+        + '\n'.join(plate_sections) + '\n'
+        '</config>\n'
+    )
 
 
 def bundle(manifest: list, stl_dir: str, output_path: str) -> None:
@@ -277,24 +401,15 @@ def bundle(manifest: list, stl_dir: str, output_path: str) -> None:
         '</model>\n'
     )
 
-    # ── 5. Build OrcaSlicer plate-assignment metadata ─────────────────────────
-    plate_sections: list = []
-    for plate_idx, obj_ids in enumerate(plate_obj_ids, start=1):
-        id_lines = '\n'.join(f'      <id value="{oid}"/>' for oid in obj_ids)
-        plate_sections.append(
-            f'  <plate>\n'
-            f'    <id value="{plate_idx}"/>\n'
-            f'    <objects_id>\n'
-            f'{id_lines}\n'
-            f'    </objects_id>\n'
-            f'  </plate>'
-        )
-    model_settings_xml = (
-        '<?xml version="1.0" encoding="UTF-8"?>\n'
-        '<config>\n'
-        + '\n'.join(plate_sections) + '\n'
-        '</config>\n'
-    )
+    # ── 5. Generate plate thumbnails and build metadata ───────────────────────
+    plate_thumbnail_paths: list = []
+    plate_thumbnail_bytes: list = []
+    for plate_idx, plate_items in enumerate(plates, start=1):
+        thumb_path = f'Metadata/plate_{plate_idx}.png'
+        plate_thumbnail_paths.append(thumb_path)
+        plate_thumbnail_bytes.append(generate_plate_thumbnail(plate_items, mesh_by_filename))
+
+    model_settings_xml = build_model_settings_xml(plate_obj_ids, plate_thumbnail_paths)
 
     # ── 6. Write ZIP ──────────────────────────────────────────────────────────
     content_types = textwrap.dedent("""\
@@ -305,7 +420,9 @@ def bundle(manifest: list, stl_dir: str, output_path: str) -> None:
           <Default Extension="model"
             ContentType="application/vnd.ms-package.3dmanufacturing-3dmodel+xml"/>
           <Default Extension="config"
-            ContentType="application/octet-stream"/>
+            ContentType="application/xml"/>
+          <Default Extension="png"
+            ContentType="image/png"/>
         </Types>
         """)
 
@@ -334,6 +451,8 @@ def bundle(manifest: list, stl_dir: str, output_path: str) -> None:
         zf.writestr('3D/model.model', model_xml)
         zf.writestr('3D/_rels/model.model.rels', model_rels)
         zf.writestr('Metadata/model_settings.config', model_settings_xml)
+        for thumb_path, thumb_bytes in zip(plate_thumbnail_paths, plate_thumbnail_bytes):
+            zf.writestr(thumb_path, thumb_bytes)
 
 
 if __name__ == '__main__':

--- a/generator/test_bundle_3mf.py
+++ b/generator/test_bundle_3mf.py
@@ -6,7 +6,45 @@ import traceback
 
 sys.path.insert(0, os.path.dirname(__file__))
 
-from bundle_3mf import autoarrange_plates, PLATE_WIDTH_MM, PLATE_DEPTH_MM, ITEM_GAP_MM, GRIDFINITY_UNIT_MM
+import io
+import xml.etree.ElementTree as ET
+from PIL import Image
+
+from bundle_3mf import (
+    autoarrange_plates,
+    build_model_settings_xml,
+    generate_plate_thumbnail,
+    PLATE_WIDTH_MM, PLATE_DEPTH_MM, ITEM_GAP_MM, GRIDFINITY_UNIT_MM, THUMBNAIL_PX,
+)
+
+
+def _make_box_mesh(w: float, d: float, h: float = 42.0):
+    """Minimal axis-aligned box mesh (8 verts, 12 tris) for use in tests."""
+    verts = [
+        (0, 0, 0), (w, 0, 0), (w, d, 0), (0, d, 0),
+        (0, 0, h), (w, 0, h), (w, d, h), (0, d, h),
+    ]
+    tris = [
+        (0, 1, 2), (0, 2, 3),  # bottom
+        (4, 5, 6), (4, 6, 7),  # top
+        (0, 1, 5), (0, 5, 4),  # front
+        (2, 3, 7), (2, 7, 6),  # back
+        (1, 2, 6), (1, 6, 5),  # right
+        (0, 3, 7), (0, 7, 4),  # left
+    ]
+    return verts, tris
+
+
+def _mesh_by_filename(plate_items: list) -> dict:
+    """Build a mock mesh_by_filename dict for a list of placed items."""
+    result = {}
+    oid = 1
+    for item in plate_items:
+        fname = item['filename']
+        if fname not in result:
+            result[fname] = (oid, *_make_box_mesh(item['width_mm'], item['depth_mm']))
+            oid += 1
+    return result
 
 
 def _item(filename, w, d):
@@ -114,6 +152,123 @@ def test_single_shelf_width_boundary():
     assert all(p['y'] == 0.0 for p in plates[0])  # all on same shelf
 
 
+def _parse_config(xml_str: str):
+    """Parse model_settings.config XML and return the ElementTree root."""
+    return ET.fromstring(xml_str.split('\n', 1)[1])  # skip <?xml?> declaration
+
+
+def test_model_settings_empty_plates():
+    xml = build_model_settings_xml([])
+    root = ET.fromstring(xml.split('\n', 1)[1])
+    assert root.tag == 'config'
+    assert list(root) == []
+
+
+def test_model_settings_single_plate_single_object():
+    xml = build_model_settings_xml([[5]])
+    root = ET.fromstring(xml.split('\n', 1)[1])
+    plates = root.findall('plate')
+    assert len(plates) == 1
+    plate = plates[0]
+    # plater_id must be 1
+    plater_id = next(m for m in plate.findall('metadata') if m.get('key') == 'plater_id')
+    assert plater_id.get('value') == '1'
+    # one model_instance
+    instances = plate.findall('model_instance')
+    assert len(instances) == 1
+    meta = {m.get('key'): m.get('value') for m in instances[0].findall('metadata')}
+    assert meta['object_id'] == '5'
+    assert meta['instance_id'] == '0'
+    assert meta['identify_id'] == '5'
+
+
+def test_model_settings_two_plates():
+    xml = build_model_settings_xml([[2, 3], [4]])
+    root = ET.fromstring(xml.split('\n', 1)[1])
+    plates = root.findall('plate')
+    assert len(plates) == 2
+    # plate 1 has two instances, plate 2 has one
+    assert len(plates[0].findall('model_instance')) == 2
+    assert len(plates[1].findall('model_instance')) == 1
+    # plater_id values are 1 and 2
+    def plater_id(plate): return next(m for m in plate.findall('metadata') if m.get('key') == 'plater_id').get('value')
+    assert plater_id(plates[0]) == '1'
+    assert plater_id(plates[1]) == '2'
+
+
+def test_model_settings_object_ids_preserved():
+    obj_ids = [10, 11, 12]
+    xml = build_model_settings_xml([obj_ids])
+    root = ET.fromstring(xml.split('\n', 1)[1])
+    instances = root.find('plate').findall('model_instance')
+    found_ids = [next(m for m in inst.findall('metadata') if m.get('key') == 'object_id').get('value')
+                 for inst in instances]
+    assert found_ids == ['10', '11', '12']
+
+
+def test_model_settings_no_objects_id_element():
+    """Ensure the old <objects_id> format is not present."""
+    xml = build_model_settings_xml([[1, 2]])
+    assert '<objects_id>' not in xml
+    assert '<id value=' not in xml
+
+
+def test_model_settings_locked_false():
+    xml = build_model_settings_xml([[1]])
+    root = ET.fromstring(xml.split('\n', 1)[1])
+    locked = next(m for m in root.find('plate').findall('metadata') if m.get('key') == 'locked')
+    assert locked.get('value') == 'false'
+
+
+def test_model_settings_thumbnail_file_included():
+    xml = build_model_settings_xml([[1]], plate_thumbnails=['Metadata/plate_1.png'])
+    root = ET.fromstring(xml.split('\n', 1)[1])
+    thumb = next(m for m in root.find('plate').findall('metadata') if m.get('key') == 'thumbnail_file')
+    assert thumb.get('value') == 'Metadata/plate_1.png'
+
+
+def test_model_settings_thumbnail_omitted_when_not_provided():
+    xml = build_model_settings_xml([[1]])
+    assert 'thumbnail_file' not in xml
+
+
+def test_model_settings_thumbnail_per_plate():
+    xml = build_model_settings_xml([[1], [2]], plate_thumbnails=['Metadata/plate_1.png', 'Metadata/plate_2.png'])
+    root = ET.fromstring(xml.split('\n', 1)[1])
+    plates = root.findall('plate')
+    for i, plate in enumerate(plates, start=1):
+        thumb = next(m for m in plate.findall('metadata') if m.get('key') == 'thumbnail_file')
+        assert thumb.get('value') == f'Metadata/plate_{i}.png'
+
+
+def test_generate_plate_thumbnail_returns_valid_png():
+    items = [{'x': 0.0, 'y': 0.0, 'width_mm': 84.0, 'depth_mm': 42.0, 'filename': 'a.stl'}]
+    png_bytes = generate_plate_thumbnail(items, _mesh_by_filename(items))
+    img = Image.open(io.BytesIO(png_bytes))
+    assert img.format == 'PNG'
+    assert img.size[0] > 100 and img.size[1] > 100
+
+
+def test_generate_plate_thumbnail_empty_plate():
+    # Empty plate has no meshes to look up — passes an empty mesh dict
+    png_bytes = generate_plate_thumbnail([], {})
+    img = Image.open(io.BytesIO(png_bytes))
+    assert img.format == 'PNG'
+    assert img.size[0] > 100 and img.size[1] > 100
+
+
+def test_generate_plate_thumbnail_multiple_items():
+    items = [
+        {'x': 0.0,  'y': 0.0,  'width_mm': 84.0,  'depth_mm': 42.0,  'filename': 'a.stl'},
+        {'x': 86.0, 'y': 0.0,  'width_mm': 42.0,  'depth_mm': 42.0,  'filename': 'b.stl'},
+        {'x': 0.0,  'y': 44.0, 'width_mm': 126.0, 'depth_mm': 84.0,  'filename': 'c.stl'},
+    ]
+    png_bytes = generate_plate_thumbnail(items, _mesh_by_filename(items))
+    img = Image.open(io.BytesIO(png_bytes))
+    assert img.format == 'PNG'
+    assert img.size[0] > 100 and img.size[1] > 100
+
+
 if __name__ == '__main__':
     tests = [
         test_empty_manifest,
@@ -127,6 +282,18 @@ if __name__ == '__main__':
         test_all_items_have_filename_preserved,
         test_positions_are_non_negative,
         test_single_shelf_width_boundary,
+        test_model_settings_empty_plates,
+        test_model_settings_single_plate_single_object,
+        test_model_settings_two_plates,
+        test_model_settings_object_ids_preserved,
+        test_model_settings_no_objects_id_element,
+        test_model_settings_locked_false,
+        test_model_settings_thumbnail_file_included,
+        test_model_settings_thumbnail_omitted_when_not_provided,
+        test_model_settings_thumbnail_per_plate,
+        test_generate_plate_thumbnail_returns_valid_png,
+        test_generate_plate_thumbnail_empty_plate,
+        test_generate_plate_thumbnail_multiple_items,
     ]
     failed = 0
     for test in tests:


### PR DESCRIPTION
## Summary

- **Fix `model_settings.config` format** — was using non-standard `<objects_id><id value="..."/>` structure; OrcaSlicer (`bbs_3mf.cpp`) expects `<model_instance>` children with `<metadata key="object_id|instance_id|identify_id" value="..."/>` elements. The old format was silently ignored, meaning plate assignments never took effect.
- **Fix `[Content_Types].xml`** — `.config` content type was `application/octet-stream`, corrected to `application/xml`.
- **3D perspective plate thumbnails** — replaced the 2D PIL flat-rectangle renderer with a matplotlib 3D renderer that uses actual STL mesh geometry. Each plate thumbnail shows the real bin shapes flat-shaded at elev=35°/azim=-50° over a dark plate surface with the Gridfinity unit grid. Thumbnails are embedded at `Metadata/plate_N.png` and referenced via `thumbnail_file` metadata in `model_settings.config`.
- **`build_model_settings_xml()`** extracted as a standalone testable function accepting optional `plate_thumbnails` list.
- **TODO added** to expose `PLATE_WIDTH_MM`/`PLATE_DEPTH_MM` as CLI args and eventually a UI input.

## Test plan

- [x] `python generator/test_bundle_3mf.py` — 23/23 passed
- [x] Docker rebuild and deploy — container healthy at localhost:32888
- [ ] Generate a 3MF in the app and open in OrcaSlicer — verify plate assignments and thumbnails display correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

https://claude.ai/code/session_01C5HHpZiP7fKcY8hhqnG1Zh