### PR TITLE
fix(3mf): correct item transforms for centered STL meshes

### DIFF
--- a/generator/bundle_3mf.py
+++ b/generator/bundle_3mf.py
@@ -254,8 +254,9 @@ def generate_plate_thumbnail(
         _, vertices, triangles = mesh_by_filename[item['filename']]
         verts = np.array(vertices, dtype=np.float64)
         tris = np.array(triangles, dtype=np.int32)
-        verts[:, 0] += item['x']
-        verts[:, 1] += item['y']
+        # Mesh is centred at local origin; shift to left/front edge position
+        verts[:, 0] += item['x'] + item['width_mm'] / 2
+        verts[:, 1] += item['y'] + item['depth_mm'] / 2
         max_z = max(max_z, float(verts[:, 2].max()))
         ax.plot_trisurf(
             verts[:, 0], verts[:, 1], verts[:, 2],
@@ -380,8 +381,13 @@ def bundle(manifest: list, stl_dir: str, output_path: str) -> None:
             mesh_id = mesh_by_filename[placed['filename']][0]
             objects_xml.append(_component_to_xml(wrapper_id, mesh_id))
 
-            x, y = placed['x'], placed['y']
-            transform = f'1 0 0 0 1 0 0 0 1 {x:.3f} {y:.3f} 0'
+            # Gridfinity STL meshes are generated with position="center" (the OpenSCAD
+            # library default), so the mesh is centred at its local origin. autoarrange
+            # returns left/front edge coordinates, so shift by half-dimensions to align
+            # the mesh centre with the intended plate position.
+            tx = placed['x'] + placed['width_mm'] / 2
+            ty = placed['y'] + placed['depth_mm'] / 2
+            transform = f'1 0 0 0 1 0 0 0 1 {tx:.3f} {ty:.3f} 0'
             items_xml.append(f'    <item objectid="{wrapper_id}" transform="{transform}"/>')
 
             ids_this_plate.append(wrapper_id)

--- a/generator/test_bundle_3mf.py
+++ b/generator/test_bundle_3mf.py
@@ -19,10 +19,15 @@ from bundle_3mf import (
 
 
 def _make_box_mesh(w: float, d: float, h: float = 42.0):
-    """Minimal axis-aligned box mesh (8 verts, 12 tris) for use in tests."""
+    """Minimal centred box mesh (8 verts, 12 tris) mirroring real STL behaviour.
+
+    Gridfinity bins are generated with position="center" so the mesh origin is at
+    the centre of the XY footprint (Z goes from 0 to h).
+    """
+    hw, hd = w / 2, d / 2
     verts = [
-        (0, 0, 0), (w, 0, 0), (w, d, 0), (0, d, 0),
-        (0, 0, h), (w, 0, h), (w, d, h), (0, d, h),
+        (-hw, -hd, 0), (hw, -hd, 0), (hw, hd, 0), (-hw, hd, 0),
+        (-hw, -hd, h), (hw, -hd, h), (hw, hd, h), (-hw, hd, h),
     ]
     tris = [
         (0, 1, 2), (0, 2, 3),  # bottom


### PR DESCRIPTION
## Summary

- Gridfinity bins are generated with `position=\"center\"` (the OpenSCAD library default), so each STL mesh is **centred at its local XY origin** — a 42mm bin occupies `-21..+21`, not `0..42`.
- `autoarrange_plates` returns left/front **edge** coordinates, so without correction every bin was shifted half its width/depth to the left and front, placing items partially or fully outside the plate boundary.
- Fix: add `width_mm / 2` and `depth_mm / 2` to the 3MF `<item>` transform so the mesh centre lands at the correct plate position.
- Same correction applied to the thumbnail vertex offset so the 3D perspective render matches actual placement.
- `_make_box_mesh` in tests updated to use centred vertices, mirroring real STL behaviour.

## Test plan

- [x] `python generator/test_bundle_3mf.py` — 23/23 passed
- [ ] Generate a 3MF and open in OrcaSlicer — verify bins land within plate boundaries

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

https://claude.ai/code/session_01C5HHpZiP7fKcY8hhqnG1Zh